### PR TITLE
prep for release 1.0.3: format_main value 'Article' is now 'Book'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,7 @@ Example Using SearchWorks Mixins:
 6. Create new Pull Request
 
 == Releases
+* <b>1.0.3</b> format_main value 'Article' is now 'Book'
 * <b>1.0.2</b> add format_main and sw_genre tests to searchworks.rb
 * <b>1.0.1</b> sw_title_display keeps appropriate trailing punct more or less per spec in solrmarc-sw sw_index.properties
 * <b>1.0.0</b> sw_full_title now includes partName and partNumber; sw_title_display created to be like sw_full_title but without trailing punctuation; sw format for typeOfResource sound recording; genre value is librettos, plural; sw format algorithm accommodates first letter upcase; genre value report does NOT map to a format, genre value 'project report' with ToR text is 'Book'

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -619,7 +619,7 @@ module Stanford
                   'technical report', 'Technical report', 'Technical Report',
                   'working paper', 'Working paper', 'Working Paper'
                   ]
-                val << 'Article' if genres and !(genres & article_genres).empty?
+                val << 'Book' if genres and !(genres & article_genres).empty?
                 val << 'Book' if issuance and issuance.include? 'monographic'
                 book_genres = ['conference publication', 'Conference publication', 'Conference Publication',
                   'instruction', 'Instruction',

--- a/lib/stanford-mods/version.rb
+++ b/lib/stanford-mods/version.rb
@@ -1,6 +1,6 @@
 module Stanford
   module Mods
     # this is the Ruby Gem version
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end

--- a/spec/searchworks_format_spec.rb
+++ b/spec/searchworks_format_spec.rb
@@ -283,47 +283,47 @@ describe "Format fields (searchworks.rb)" do
       expect(@smods_rec.format_main).to eq ['Archive/Manuscript']
     end
 
-    context "Article: typeOfResource text, genre" do
+    context "Book, formerly Article: typeOfResource text, genre" do
       it "'article'" do
         m = "<mods #{@ns_decl}><typeOfResource>text</typeOfResource><genre authority=\"marcgt\">article</genre></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><typeOfResource>text</typeOfResource><genre authority=\"marcgt\">Article</genre></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "'book chapter'", :email => 'mods-squad 2014-05-22, Joanna Dyla' do
         m = "<mods #{@ns_decl}><genre authority=\"local\">book chapter</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Book chapter</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Book Chapter</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "'issue brief'", :email => 'mods-squad 2014-05-22, Joanna Dyla' do
         m = "<mods #{@ns_decl}><genre authority=\"local\">issue brief</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Issue brief</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Issue Brief</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "'project report'", :jira => 'GRYP-170', :github => 'gdor-indexer/#7' do
         m = "<mods #{@ns_decl}><genre>project report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre>Project report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre>Project Report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "'report' isn't valid", :jira => 'GRYP-170', :github => 'gdor-indexer/#7' do
         m = "<mods #{@ns_decl}><genre>report</genre><typeOfResource>text</typeOfResource></mods>"
@@ -333,38 +333,38 @@ describe "Format fields (searchworks.rb)" do
       it "'student project report'", :consul => '/NGDE/Format 2014-05-28' do
         m = "<mods #{@ns_decl}><genre authority=\"local\">student project report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Student project report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Student Project report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Student Project Report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "'technical report'", :jira => 'GRYPHONDOR-207' do
         m = "<mods #{@ns_decl}><genre authority=\"marcgt\">technical report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"marcgt\">Technical report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"marcgt\">Technical Report</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "'working paper'", :email => 'mods-squad 2014-05-22, Joanna Dyla' do
         m = "<mods #{@ns_decl}><genre authority=\"local\">working paper</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Working paper</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
         m = "<mods #{@ns_decl}><genre authority=\"local\">Working Paper</genre><typeOfResource>text</typeOfResource></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
     end # Article
 
@@ -536,12 +536,12 @@ describe "Format fields (searchworks.rb)" do
       it "multiple genre elements, single typeOfResource" do
         m = "<mods #{@ns_decl}><typeOfResource>text</typeOfResource><genre>librettos</genre><genre>article</genre></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article', 'Book']
+        expect(@smods_rec.format_main).to eq ['Book']
       end
       it "mish mash" do
         m = "<mods #{@ns_decl}><typeOfResource>text</typeOfResource><typeOfResource>still image</typeOfResource><genre>librettos</genre><genre>article</genre></mods>"
         @smods_rec.from_str(m)
-        expect(@smods_rec.format_main).to eq ['Article', 'Book', 'Image']
+        expect(@smods_rec.format_main).to eq ['Book', 'Image']
       end
       it "doesn't give duplicate values" do
         m = "<mods #{@ns_decl}><typeOfResource>text</typeOfResource><genre>librettos</genre><genre>thesis</genre></mods>"


### PR DESCRIPTION
per https://jirasul.stanford.edu/jira/browse/INDEX-154,  we want Book in lieu of Article as format_main value.

@lmcglohon 
