### PR TITLE
Change in mechanism for determining dates for display only and for indexing, sorting, and faceting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 script: rake rspec
 rvm:
-  - 2.1.1
+  - 2.2.0
+  - 2.1.5
   - 2.0.0
   - 1.9.3
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ rvm:
   - 2.0.0
   - 1.9.3
   - ruby-head
-  - jruby-19mode # JRuby in 1.9 mode
+  - jruby-1.7.9-d19 # fails after 1.7.10 for some reason
+#  - jruby-19mode # JRuby in 1.9 mode
 #  - jruby-head  # failing 2014-07
 notifications:
   email:

--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,7 @@ Example Using SearchWorks Mixins:
 6. Create new Pull Request
 
 == Releases
+* <b>1.1.0</b> Changed mechanism for determining dates for display only and for indexing, sorting, and faceting and removed deprecated pub_date_group method
 * <b>1.0.3</b> format_main value 'Article' is now 'Book'
 * <b>1.0.2</b> add format_main and sw_genre tests to searchworks.rb
 * <b>1.0.1</b> sw_title_display keeps appropriate trailing punct more or less per spec in solrmarc-sw sw_index.properties

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -391,34 +391,6 @@ module Stanford
         end
       end
 
-      # @return [Array<String>] values for the pub_date_group_facet
-      # @deprecated
-      def pub_date_groups year
-        if not year
-          return nil
-        end
-        year=year.to_i
-        current_year=Time.new.year.to_i
-        result = []
-        if year >= current_year - 1
-          result << "This year"
-        else
-          if year >= current_year - 3
-            result << "Last 3 years"
-          else
-            if year >= current_year - 10
-              result << "Last 10 years"
-            else
-              if year >= current_year - 50
-                result << "Last 50 years"
-              else
-                result << "More than 50 years ago"
-              end
-            end
-          end
-        end
-      end
-
       #get the dates from dateIssued, and dateCreated merged into 1 array.
       # @return [Array<String>] values for the issue_date_display Solr field for this document or nil if none
       def pub_dates

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -383,39 +383,6 @@ module Stanford
         vals
       end
 
-      # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding="marc"
-      def dates_marc_encoding
-        split_date_encodings unless @dates_marc_encoding
-        return @dates_marc_encoding
-      end
-
-      # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding not "marc"
-      def dates_no_marc_encoding
-        split_date_encodings unless @dates_no_marc_encoding
-        return @dates_no_marc_encoding
-      end
-
-      # Populate @dates_marc_encoding and @dates_no_marc_encoding from dateIssued and dateCreated tags from origin_info 
-      # with and without encoding=marc
-      def split_date_encodings
-        @dates_marc_encoding = []
-        @dates_no_marc_encoding = []
-        self.origin_info.dateIssued.each { |di|
-          if di.encoding == "marc"
-            @dates_marc_encoding << di.text
-          else
-            @dates_no_marc_encoding << di.text
-          end
-        }
-        self.origin_info.dateCreated.each { |dc|
-          if dc.encoding == "marc"
-            @dates_marc_encoding << dc.text
-          else
-            @dates_no_marc_encoding << dc.text
-          end 
-        }
-      end
-
       # For the date display only, the first place to look is in the dates without encoding=marc array.
       # If no such dates, select the first date in the pub_dates array.  Otherwise return nil
       # @return [String] value for the pub_date_display Solr field for this document or nil if none
@@ -816,7 +783,40 @@ module Stanford
           end
         end 
         return nil
-      end      
+      end
+
+      # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding="marc"
+      def dates_marc_encoding
+        split_date_encodings unless @dates_marc_encoding
+        return @dates_marc_encoding
+      end
+
+      # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding not "marc"
+      def dates_no_marc_encoding
+        split_date_encodings unless @dates_no_marc_encoding
+        return @dates_no_marc_encoding
+      end
+
+      # Populate @dates_marc_encoding and @dates_no_marc_encoding from dateIssued and dateCreated tags from origin_info 
+      # with and without encoding=marc
+      def split_date_encodings
+        @dates_marc_encoding = []
+        @dates_no_marc_encoding = []
+        self.origin_info.dateIssued.each { |di|
+          if di.encoding == "marc"
+            @dates_marc_encoding << di.text
+          else
+            @dates_no_marc_encoding << di.text
+          end
+        }
+        self.origin_info.dateCreated.each { |dc|
+          if dc.encoding == "marc"
+            @dates_marc_encoding << dc.text
+          else
+            @dates_no_marc_encoding << dc.text
+          end
+        }
+      end
     end # class Record
   end # Module Mods
 end # Module Stanford

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -383,27 +383,20 @@ module Stanford
         vals
       end
 
-      # @return [Array<String>] dates with encoding="marc"
+      # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding="marc"
       def dates_marc_encoding
-        if @dates_marc_encoding
-          return @dates_marc_encoding
-        else
-          split_date_encodings
-          return @dates_marc_encoding
-        end
+        split_date_encodings unless @dates_marc_encoding
+        return @dates_marc_encoding
       end
 
-      # @return [Array<String>] dates with encoding not "marc"
+      # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding not "marc"
       def dates_no_marc_encoding
-        if @dates_no_marc_encoding
-          return @dates_no_marc_encoding
-        else
-          split_date_encodings
-          return @dates_no_marc_encoding
-        end
+        split_date_encodings unless @dates_no_marc_encoding
+        return @dates_no_marc_encoding
       end
 
-      # Get arrays of dateIssued and dateCreated tags from origin_info with and without encoding=marc for different uses
+      # Populate @dates_marc_encoding and @dates_no_marc_encoding from dateIssued and dateCreated tags from origin_info 
+      # with and without encoding=marc
       def split_date_encodings
         @dates_marc_encoding = []
         @dates_no_marc_encoding = []
@@ -424,7 +417,7 @@ module Stanford
       end
 
       # For the date display only, the first place to look is in the dates without encoding=marc array.
-      # Next, select the first date in the pub_dates array.  Otherwise return nil
+      # If no such dates, select the first date in the pub_dates array.  Otherwise return nil
       # @return [String] value for the pub_date_display Solr field for this document or nil if none
       def pub_date_display
           return dates_no_marc_encoding.first unless dates_no_marc_encoding.empty?

--- a/lib/stanford-mods/version.rb
+++ b/lib/stanford-mods/version.rb
@@ -1,6 +1,6 @@
 module Stanford
   module Mods
     # this is the Ruby Gem version
-    VERSION = "1.0.3"
+    VERSION = "1.1.0"
   end
 end

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -122,6 +122,16 @@ describe "Date methods (searchworks.rb)" do
       @smods_rec.pub_date_sort.should =='0800'
       @smods_rec.pub_date_facet.should == '9th century'
     end  
+    it 'should use the dateIssued without marc encoding for pub_date_display and the one with marc encoding for indexing, sorting and faceting' do
+      m = "<mods #{@ns_decl}><originInfo><dateIssued>[186-?]</dateIssued><dateIssued encoding=\"marc\">1860</dateIssued><issuance>monographic</issuance></originInfo>"
+      @smods_rec = Stanford::Mods::Record.new
+      @smods_rec.from_str(m)
+
+      @smods_rec.pub_date_display.should == '[186-?]'
+      @smods_rec.pub_date.should =='1860'
+      @smods_rec.pub_date_sort.should =='1860'
+      @smods_rec.pub_date_facet.should == '1860'
+    end
   end # pub_date
 
   context "dates with u notation (198u, 19uu)" do    

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -204,31 +204,4 @@ describe "Date methods (searchworks.rb)" do
     end
   end
 
-  context "pub_date_groups" do
-    it 'should generate the groups' do
-      m = "<mods #{@ns_decl}><originInfo>
-      <dateCreated>1904</dateCreated>
-      </originInfo></mods>"
-      @smods_rec = Stanford::Mods::Record.new
-      @smods_rec.from_str(m)
-      @smods_rec.pub_date_groups(1904).should == ['More than 50 years ago']
-    end
-    it 'should work for a modern date too' do
-      m = "<mods #{@ns_decl}><originInfo>
-      <dateCreated>1904</dateCreated>
-      </originInfo></mods>"
-      @smods_rec = Stanford::Mods::Record.new
-      @smods_rec.from_str(m)
-      @smods_rec.pub_date_groups(2013).should == ["This year"]
-    end
-    it 'should work ok given a nil date' do
-      m = "<mods #{@ns_decl}><originInfo>
-      <dateCreated>1904</dateCreated>
-      </originInfo></mods>"
-      @smods_rec = Stanford::Mods::Record.new
-      @smods_rec.from_str(m)
-      @smods_rec.pub_date_groups(nil).should == nil
-    end
-  end #context pub date groups
-
 end


### PR DESCRIPTION
For display only, the first source of data should be the dates in the dateIssued and dateCreated tags in the origin_info tag that do not have an encoding attribute of marc.  If there are none, the next source is the date tags with encoding="marc" or nil.  

For indexing, sorting, and faceting, the first source are the same date fields that do have an encoding attribute of marc.  If there are none, the next source is the date tags without encoding="marc" or nil.

Also, removed pub_date_group def and tests which became unnecessary with the SW redesign in Summer of 2014.

@ndushay 