### PR TITLE
Update pub_date_display to use dates_no_marc_encoding.first

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,7 @@ Example Using SearchWorks Mixins:
 6. Create new Pull Request
 
 == Releases
+* <b>1.1.1</b> Minor bug fixes
 * <b>1.1.0</b> Changed mechanism for determining dates for display only and for indexing, sorting, and faceting and removed deprecated pub_date_group method
 * <b>1.0.3</b> format_main value 'Article' is now 'Book'
 * <b>1.0.2</b> add format_main and sw_genre tests to searchworks.rb

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -384,11 +384,11 @@ module Stanford
       end
 
       # For the date display only, the first place to look is in the dates without encoding=marc array.
-      # If no such dates, select the first date in the pub_dates array.  Otherwise return nil
+      # If no such dates, select the first date in the dates_marc_encoding array.  Otherwise return nil
       # @return [String] value for the pub_date_display Solr field for this document or nil if none
       def pub_date_display
           return dates_no_marc_encoding.first unless dates_no_marc_encoding.empty?
-          return pub_dates.first unless pub_dates.empty?
+          return dates_marc_encoding.first unless dates_marc_encoding.empty?
           return nil
       end
 
@@ -787,19 +787,23 @@ module Stanford
 
       # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding="marc"
       def dates_marc_encoding
-        split_date_encodings unless @dates_marc_encoding
-        return @dates_marc_encoding
+        @dates_marc_encoding ||= begin
+          parse_dates_from_originInfo
+          @dates_marc_encoding
+        end
       end
 
       # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding not "marc"
       def dates_no_marc_encoding
-        split_date_encodings unless @dates_no_marc_encoding
-        return @dates_no_marc_encoding
+        @dates_no_marc_encoding ||= begin
+          parse_dates_from_originInfo
+          @dates_no_marc_encoding
+        end
       end
 
       # Populate @dates_marc_encoding and @dates_no_marc_encoding from dateIssued and dateCreated tags from origin_info 
       # with and without encoding=marc
-      def split_date_encodings
+      def parse_dates_from_originInfo
         @dates_marc_encoding = []
         @dates_no_marc_encoding = []
         self.origin_info.dateIssued.each { |di|

--- a/lib/stanford-mods/version.rb
+++ b/lib/stanford-mods/version.rb
@@ -1,6 +1,6 @@
 module Stanford
   module Mods
     # this is the Ruby Gem version
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
Update pub_date_display to use dates_no_marc_encoding.first instead of pub_dates.first, refactored dates_marc_encoding and dates_no_marc_encoding with a rename of split_date_encodings to  parse_dates_from_originInfo as a better method name