### PR TITLE
Corrected java Character.MAX_CODE_POINT value from \u{FFFF} to \u{10FFFF}

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,7 @@ Example Using SearchWorks Mixins:
 6. Create new Pull Request
 
 == Releases
+* <b>1.1.2</b> Corrected java Character.MAX_CODE_POINT value from \u{FFFF} to \u{10FFFF}
 * <b>1.1.1</b> Minor bug fixes
 * <b>1.1.0</b> Changed mechanism for determining dates for display only and for indexing, sorting, and faceting and removed deprecated pub_date_group method
 * <b>1.0.3</b> format_main value 'Article' is now 'Book'

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -90,7 +90,7 @@ module Stanford
       # @return [String] value for author_sort field
       def sw_sort_author
         #  substitute java Character.MAX_CODE_POINT for nil main_author so missing main authors sort last
-        val = '' + (main_author_w_date ? main_author_w_date : "\u{FFFF} ") + ( sort_title ? sort_title : '')
+        val = '' + (main_author_w_date ? main_author_w_date : "\u{10FFFF} ") + ( sort_title ? sort_title : '')
         val.gsub(/[[:punct:]]*/, '').strip
       end
       

--- a/lib/stanford-mods/version.rb
+++ b/lib/stanford-mods/version.rb
@@ -1,6 +1,6 @@
 module Stanford
   module Mods
     # this is the Ruby Gem version
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end

--- a/spec/searchworks_spec.rb
+++ b/spec/searchworks_spec.rb
@@ -99,8 +99,8 @@ describe "Searchworks mixin for Stanford::Mods::Record" do
         r = Stanford::Mods::Record.new
         r.from_str "<mods #{@ns_decl}><titleInfo><title>Jerk</title></titleInfo></mods>"
         r.sw_sort_author.should =~ / Jerk$/
-        r.sw_sort_author.should match("\u{FFFF}")
-        r.sw_sort_author.should match("\xEF\xBF\xBF")
+        r.sw_sort_author.should match("\u{10FFFF}")
+        r.sw_sort_author.should match("\xF4\x8F\xBF\xBF")
       end
       it "should not have any punctuation marks" do
         r = Stanford::Mods::Record.new


### PR DESCRIPTION
Was getting errror with \u{FFFF} so double checked it here: http://docs.oracle.com/javase/7/docs/api/java/lang/Character.html

@ndushay