### PR TITLE
date parsing: facet_string (and string_sortable) _from_date_str

### DIFF
--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -32,6 +32,31 @@ module Stanford
         result
       end
 
+      # get String sortable value year if we can parse date_str to get a year.
+      #   SearchWorks currently uses a string field for pub date sorting; thus so does Spotlight.
+      #   The values returned must *lexically* sort in chronological order, so the B.C. dates are tricky
+      # @param [String] date_str String containing a date (we hope)
+      # @return [String, nil] String sortable year if we could parse one, nil otherwise
+      #  note that these values must *lexically* sort to create a chronological sort.
+      def self.sortable_year_string_from_date_str(date_str)
+        # B.C. first in case there are 4 digits, e.g. 1600 B.C.
+        return sortable_year_for_bc(date_str) if date_str.match(BC_REGEX)
+        # most date strings have a four digit year
+        result = sortable_year_for_yyyy(date_str)
+        result ||= sortable_year_for_yy(date_str)
+        result ||= sortable_year_for_decade(date_str)
+        result ||= sortable_year_for_century(date_str)
+        result ||= sortable_year_for_early_numeric(date_str)
+        unless result
+          # try removing brackets between digits in case we have 169[5] or [18]91
+          if date_str.match(/\d[\[\]]\d/)
+            no_brackets = date_str.delete('[]')
+            return sortable_year_string_from_date_str(no_brackets)
+          end
+        end
+        result
+      end
+
       # looks for 4 consecutive digits in String and returns first occurence if found
       # @param [String] date_str String containing four digit year (we hope)
       # @return [String, nil] 4 digit year (e.g. 1865, 0950) if date_str has yyyy, nil otherwise

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -6,6 +6,8 @@ module Stanford
     #     - we may want an integer or date sort field as well as lexical
     #     - we may want to either make this a module (a collection of methods another class can use)
     #       or have an initialize method so we don't have to keep passing the date_str argument
+    #       (e.g. we could have  my_date.bc? and my_date.sortable_year_for_dddd, esp for any method
+    #       with 'for' rather than 'from_date_str')
     class DateParsing
 
       # get single facet value for date, generally an explicit year or "17th century" or "5 B.C."
@@ -56,6 +58,10 @@ module Stanford
         end
         result
       end
+
+      # TODO:  particularly for the methods below (xxx_for_zzz), we should probably
+      #   have an instance in play, rather than class methods.  This would allow the methods
+      #   above to avoid passing date_str in over and over.
 
       # looks for 4 consecutive digits in String and returns first occurence if found
       # @param [String] date_str String containing four digit year (we hope)

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -8,10 +8,10 @@ module Stanford
     #       or have an initialize method so we don't have to keep passing the date_str argument
     class DateParsing
 
-      # looks for dddd pattern in String and returns it if found
+      # looks for 4 consecutive digits in String and returns first occurence if found
       # @param [String] date_str String containing four digit year (we hope)
       # @return [String, nil] 4 digit year (e.g. 1865, 0950) if date_str has yyyy, nil otherwise
-      def self.sortable_year_from_date_str(date_str)
+      def self.sortable_year_for_yyyy(date_str)
         matches = date_str.match(/\d{4}/) if date_str
         return matches.to_s if matches
       end
@@ -23,7 +23,7 @@ module Stanford
       #   1/1/25  ->  1925
       # @param [String] date_str String containing x/x/yy or x-x-yy date pattern
       # @return [String, nil] 4 digit year (e.g. 1865, 0950) if date_str matches pattern, nil otherwise
-      def self.sortable_year_from_yy(date_str)
+      def self.sortable_year_for_yy(date_str)
         return unless date_str
         slash_matches = date_str.match(/\d{1,2}\/\d{1,2}\/\d{2}/)
         if slash_matches
@@ -44,11 +44,11 @@ module Stanford
       #   note that these are the only decade patterns found in our actual date strings in MODS records
       # @param [String] date_str String containing yyyu, yyy-, yyy? or yyyx decade pattern
       # @return [String, nil] 4 digit year (e.g. 1860, 1950) if date_str matches pattern, nil otherwise
-      def self.sortable_year_from_decade(date_str)
+      def self.sortable_year_for_decade(date_str)
         decade_matches = date_str.match(/\d{3}[u\-?x]/) if date_str
         if decade_matches
           changed_to_zero = decade_matches.to_s.tr('u\-?x', '0')
-          return sortable_year_from_date_str(changed_to_zero)
+          return sortable_year_for_yyyy(changed_to_zero)
         end
       end
 
@@ -59,7 +59,7 @@ module Stanford
       #   note that these are the only century patterns found in our actual date strings in MODS records
       # @param [String] date_str String containing yyuu, yy--, yy--? or xxth century pattern
       # @return [String, nil] yy00 if date_str matches pattern, nil otherwise; also nil if B.C. in pattern
-      def self.sortable_year_from_century(date_str)
+      def self.sortable_year_for_century(date_str)
         return unless date_str
         return if date_str.match(/B\.C\./)
         century_matches = date_str.match(CENTURY_4CHAR_REGEXP)
@@ -145,7 +145,7 @@ module Stanford
         date_str.rjust(4, '0')
       end
 
-      # NOTE:  while Date.parse() works for many dates, the *sortable_year_from_date_str
+      # NOTE:  while Date.parse() works for many dates, the *sortable_year_for_yyyy
       #   actually works for nearly all those cases and a lot more besides.  Trial and error
       #   with an extensive set of test data culled from actual date strings in our MODS records
       #   has made this method bogus.

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -8,6 +8,30 @@ module Stanford
     #       or have an initialize method so we don't have to keep passing the date_str argument
     class DateParsing
 
+      # get single facet value for date, generally an explicit year or "17th century" or "5 B.C."
+      # @param [String] date_str String containing a date (we hope)
+      # @return [String, nil] String facet value for year if we could parse one, nil otherwise
+      def self.facet_string_from_date_str(date_str)
+        # B.C. first in case there are 4 digits, e.g. 1600 B.C.
+        return facet_string_for_bc(date_str) if date_str.match(BC_REGEX)
+        # most date strings have a four digit year
+        result ||= sortable_year_for_yyyy(date_str)
+        # 2 digit year will always be 19xx or 20xx; sortable version will make a good facet string
+        result ||= sortable_year_for_yy(date_str)
+        # decades are always 19xx or 20xx; sortable version will make a good facet string
+        result ||= sortable_year_for_decade(date_str)
+        result ||= facet_string_for_century(date_str)
+        result ||= facet_string_for_early_numeric(date_str)
+        unless result
+          # try removing brackets between digits in case we have 169[5] or [18]91
+          if date_str.match(/\d[\[\]]\d/)
+            no_brackets = date_str.delete('[]')
+            return facet_string_from_date_str(no_brackets)
+          end
+        end
+        result
+      end
+
       # looks for 4 consecutive digits in String and returns first occurence if found
       # @param [String] date_str String containing four digit year (we hope)
       # @return [String, nil] 4 digit year (e.g. 1865, 0950) if date_str has yyyy, nil otherwise

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -14,29 +14,38 @@ module Stanford
 
 # -- likely to be private or protected
 
-      # return all /originInfo/dateCreated elements in MODS records
-      # @return [Nokogiri::XML::NodeSet<Nokogiri::XML::Element>]
-      def date_created_nodeset
-        @mods_ng_xml.origin_info.dateCreated   # returns nokogiri element/node objects
+      # return /originInfo/dateCreated elements in MODS records
+      # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute)
+      #   should be excluded; false approximate dates should be included
+      # @return [Array<Nokogiri::XML::Element>]
+      def date_created_elements(ignore_approximate=false)
+        date_created_nodeset = @mods_ng_xml.origin_info.dateCreated
+        return self.class.remove_approximate(date_created_nodeset) if ignore_approximate
+        date_created_nodeset.to_a
       end
 
-      # return all /originInfo/dateIssued elements in MODS records
-      # @return [Nokogiri::XML::NodeSet<Nokogiri::XML::Element>]
-      def date_issued_nodeset
-        @mods_ng_xml.origin_info.dateIssued   # returns nokogiri element/node objects
+      # return /originInfo/dateIssued elements in MODS records
+      # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute)
+      #   should be excluded; false approximate dates should be included
+      # @return [Array<Nokogiri::XML::Element>]
+      def date_issued_elements(ignore_approximate=false)
+        date_issued_nodeset = @mods_ng_xml.origin_info.dateIssued
+        return self.class.remove_approximate(date_issued_nodeset) if ignore_approximate
+        date_issued_nodeset.to_a
       end
 
       # given a set of date elements, return the single element with attribute keyDate="yes"
       #  or return nil if no elements have attribute keyDate="yes", or if multiple elements have keyDate="yes"
-      # @param [Nokogiri::XML::NodeSet<Nokogiri::XML::Element>] nodeset set of date elements
+      # @param [Array<Nokogiri::XML::Element>] Array of date elements
       # @return [Nokogiri::XML::Element, nil] single date element with attribute keyDate="yes", or nil
-      def self.keyDate(nodeset)
-        keyDates = nodeset.select { |node| node["keyDate"] == 'yes' }
+      def self.keyDate(elements)
+        keyDates = elements.select { |node| node["keyDate"] == 'yes' }
         return keyDates.first if keyDates.size == 1
       end
 
+      # remove Elements from NodeSet if they have a qualifier attribute of 'approximate' or 'questionable'
       # @param [Nokogiri::XML::NodeSet<Nokogiri::XML::Element>] nodeset set of date elements
-      # @return [Nokogiri::XML::NodeSet<Nokogiri::XML::Element>] the set of date elements minus any that
+      # @return [Array<Nokogiri::XML::Element>] the set of date elements minus any that
       #   had a qualifier attribute of 'approximate' or 'questionable'
       def self.remove_approximate(nodeset)
         nodeset.select { |node| node unless date_is_approximate?(node) }

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -371,6 +371,17 @@ describe "date parsing methods" do
     '33' => '0033',
     '945' => '0945'
   }
+  bc_dates = {
+    # note that values must lexically sort to create a chronological sort (800 B.C. before 750 B.C.)
+    '801 B.C.' => '-199',
+    '800 B.C.' => '-200',
+    '750 B.C.' => '-250',
+    '700 B.C.' => '-300',
+    '699 B.C.' => '-301',
+    '75 B.C.' => '-925',
+    '8 B.C.' => '-992'
+  }
+
 
   context '*sortable_year_for_yyyy' do
     single_year
@@ -527,32 +538,18 @@ describe "date parsing methods" do
   end
 
   context '*sortable_year_for_bc' do
-    it '-700 for 300 B.C. (so 300 B.C. lexically sorts before 200 B.C.)' do
-      expect(Stanford::Mods::DateParsing.sortable_year_for_bc('300 B.C.')).to eq '-700'
-    end
-    it '-750 for 250 B.C. (so 250 B.C. lexically sorts between 200 B.C. and 300 B.C.)' do
-      expect(Stanford::Mods::DateParsing.sortable_year_for_bc('250 B.C.')).to eq '-750'
-    end
-    it '-800 for 200 B.C. (so 200 B.C. lexically sorts after 300 B.C.)' do
-      expect(Stanford::Mods::DateParsing.sortable_year_for_bc('200 B.C.')).to eq '-800'
-    end
-    it '-801 for 199 B.C. (so 199 B.C. lexically sorts after 200 B.C.)' do
-      expect(Stanford::Mods::DateParsing.sortable_year_for_bc('199 B.C.')).to eq '-801'
-    end
-    it '-925 for 75 B.C.' do
-      expect(Stanford::Mods::DateParsing.sortable_year_for_bc('75 B.C.')).to eq '-925'
-    end
-    it '-992 for 8 B.C.' do
-      expect(Stanford::Mods::DateParsing.sortable_year_for_bc('8 B.C.')).to eq '-992'
+    bc_dates.each do |example, expected|
+      it "#{expected} for #{example}" do
+        expect(Stanford::Mods::DateParsing.sortable_year_for_bc(example)).to eq expected
+      end
     end
   end
 
   context '*facet_string_for_bc' do
-    it '250 B.C. for 250 B.C.' do
-      expect(Stanford::Mods::DateParsing.facet_string_for_bc('250 B.C.')).to eq '250 B.C.'
-    end
-    it '199 B.C. for 199 B.C.' do
-      expect(Stanford::Mods::DateParsing.facet_string_for_bc('199 B.C.')).to eq '199 B.C.'
+    bc_dates.keys.each do |example|
+      it "#{example} for #{example}" do
+        expect(Stanford::Mods::DateParsing.facet_string_for_bc(example)).to eq example
+      end
     end
     it '1600 B.C. for 1600 B.C.' do
       expect(Stanford::Mods::DateParsing.facet_string_for_bc('1600 B.C.')).to eq '1600 B.C.'

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -428,6 +428,45 @@ describe "date parsing methods" do
     end
   end
 
+  context '*sortable_year_string_from_date_str' do
+    single_year
+      .merge(specific_month)
+      .merge(specific_day)
+      .merge(specific_day_2_digit_year)
+      .merge(specific_day_ruby_parse_fail)
+      .merge(early_numeric_dates)
+      .merge(bc_dates)
+      .merge(brackets_in_middle_of_year)
+      .merge(invalid_but_can_get_year).each do |example, expected|
+      it "#{expected} for single value #{example}" do
+        expect(Stanford::Mods::DateParsing.sortable_year_string_from_date_str(example)).to eq expected
+      end
+    end
+
+    multiple_years
+      .merge(multiple_years_4_digits_once)
+      .merge(decade_only)
+      .merge(decade_only_4_digits).each do |example, expected|
+      it "#{expected.first} for multi-value #{example}" do
+        expect(Stanford::Mods::DateParsing.sortable_year_string_from_date_str(example)).to eq expected.first
+      end
+    end
+
+    century_only.keys.each do |example|
+      it "1700 from #{example}" do
+        expect(Stanford::Mods::DateParsing.sortable_year_string_from_date_str(example)).to eq '1700'
+      end
+    end
+    it '0700 for 7--' do
+      expect(Stanford::Mods::DateParsing.sortable_year_string_from_date_str('7--')).to eq '0700'
+    end
+
+    it 'nil for 1600 B.C.' do
+      skip "code broken for dddd B.C. but no existing data for this yet"
+      expect(Stanford::Mods::DateParsing.sortable_year_string_from_date_str('1600 B.C.')).to eq nil
+    end
+  end
+
   context '*sortable_year_for_yyyy' do
     single_year
       .merge(specific_month)

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -382,6 +382,51 @@ describe "date parsing methods" do
     '8 B.C.' => '-992'
   }
 
+  context '*facet_string_from_date_str' do
+    single_year
+      .merge(specific_month)
+      .merge(specific_day)
+      .merge(specific_day_2_digit_year)
+      .merge(specific_day_ruby_parse_fail)
+      .merge(century_only)
+      .merge(brackets_in_middle_of_year)
+      .merge(invalid_but_can_get_year).each do |example, expected|
+      it "#{expected} for single value #{example}" do
+        expect(Stanford::Mods::DateParsing.facet_string_from_date_str(example)).to eq expected
+      end
+    end
+
+    multiple_years
+      .merge(multiple_years_4_digits_once)
+      .merge(decade_only)
+      .merge(decade_only_4_digits).each do |example, expected|
+      it "#{expected.first} for multi-value #{example}" do
+        expect(Stanford::Mods::DateParsing.facet_string_from_date_str(example)).to eq expected.first
+      end
+    end
+
+    early_numeric_dates.each do |example, expected|
+      if example.start_with?('-')
+        exp = example[1..-1] + " B.C."
+        it "#{exp} for #{example}" do
+          expect(Stanford::Mods::DateParsing.facet_string_from_date_str(example)).to eq exp
+        end
+      else
+        it "#{expected} for #{example}" do
+          expect(Stanford::Mods::DateParsing.facet_string_from_date_str(example)).to eq expected
+        end
+      end
+    end
+
+    bc_dates.keys.each do |example|
+      it "#{example} for #{example}" do
+        expect(Stanford::Mods::DateParsing.facet_string_from_date_str(example)).to eq example
+      end
+    end
+    it '1600 B.C. for 1600 B.C.' do
+      expect(Stanford::Mods::DateParsing.facet_string_from_date_str('1600 B.C.')).to eq '1600 B.C.'
+    end
+  end
 
   context '*sortable_year_for_yyyy' do
     single_year

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -22,14 +22,6 @@ describe "date parsing methods" do
     '[s.d.]',
     'Undated'
   ]
-  century_only = {
-    '18th century CE' => '18th century',
-    '17uu' => '18th century',
-    '17--?]' => '18th century',
-    '17--]' => '18th century',
-    '[17--]' => '18th century',
-    '[17--?]' => '18th century'
-  }
   # example string as key, expected parsed value as value
   invalid_but_can_get_year = {
     '1966-14-14' => '1966',  # 14 isn't a valid month ...
@@ -355,13 +347,21 @@ describe "date parsing methods" do
     '186?' => ['1860', '1861', '1862', '1863', '1864', '1865', '1866', '1867', '1868', '1869'],
     '195x' => ['1950', '1951', '1952', '1953', '1954', '1955', '1956', '1957', '1958', '1959']
   }
+  century_only = {
+    '18th century CE' => '18th century',
+    '17uu' => '18th century',
+    '17--?]' => '18th century',
+    '17--]' => '18th century',
+    '[17--]' => '18th century',
+    '[17--?]' => '18th century'
+  }
   brackets_in_middle_of_year = {
     '169[5]' => '1695',
     'October 3, [18]91' => '1891'
   }
   # we have data like this for our Roman coins collection
   early_numeric_dates = {
-    # note that these values must lexically sort to create a chronological sort.
+    # note that values must lexically sort to create a chronological sort. (-999 before -914)
     '-999' => '-001',
     '-914' => '-086',
     '-18' => '-982',
@@ -377,26 +377,26 @@ describe "date parsing methods" do
       .merge(specific_month)
       .merge(specific_day)
       .merge(invalid_but_can_get_year).each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected
       end
     end
 
     multiple_years.each do |example, expected|
-      it "gets #{expected.first} from #{example}" do
+      it "#{expected.first} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected.first
       end
     end
 
     specific_day_ruby_parse_fail.each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected
       end
     end
 
     multiple_years_4_digits_once
       .merge(decade_only_4_digits).each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected.first
       end
     end
@@ -415,7 +415,7 @@ describe "date parsing methods" do
 
   context '*sortable_year_for_yy' do
     specific_day_2_digit_year.each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_yy(example)).to eq expected
       end
     end
@@ -430,7 +430,7 @@ describe "date parsing methods" do
       expect(Stanford::Mods::DateParsing.sortable_year_for_yy('92-31-1')).to eq nil
     end
     decade_only.keys.each do |example|
-      it "gets nil from #{example}" do
+      it "nil for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_yy(example)).to eq nil
       end
     end
@@ -438,7 +438,7 @@ describe "date parsing methods" do
 
   context '*sortable_year_for_decade' do
     decade_only.each do |example, expected|
-      it "gets #{expected.first} from #{example}" do
+      it "#{expected.first} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_decade(example)).to eq expected.first
       end
     end
@@ -457,7 +457,7 @@ describe "date parsing methods" do
     # some strings this method cannot handle (and must be parsed with other class methods)
     decade_only_4_digits.keys
       .push(*specific_day_2_digit_year.keys).each do |example|
-      it "gets nil from #{example}" do
+      it "nil for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_decade(example)).to eq nil
       end
     end
@@ -465,7 +465,7 @@ describe "date parsing methods" do
 
   context '*sortable_year_for_century' do
     century_only.keys.each do |example|
-      it "gets 1700 from #{example}" do
+      it "1700 from #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_century(example)).to eq '1700'
       end
     end
@@ -479,7 +479,7 @@ describe "date parsing methods" do
 
   context '*facet_string_for_century' do
     century_only.each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.facet_string_for_century(example)).to eq expected
       end
     end
@@ -505,7 +505,7 @@ describe "date parsing methods" do
 
   context '*sortable_year_for_early_numeric' do
     early_numeric_dates.each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.sortable_year_for_early_numeric(example)).to eq expected
       end
     end
@@ -515,11 +515,11 @@ describe "date parsing methods" do
     early_numeric_dates.each do |example, expected|
       if example.start_with?('-')
         exp = example[1..-1] + " B.C."
-        it "gets #{exp} from #{example}" do
+        it "#{exp} for #{example}" do
           expect(Stanford::Mods::DateParsing.facet_string_for_early_numeric(example)).to eq exp
         end
       else
-        it "gets #{expected} from #{example}" do
+        it "#{expected} for #{example}" do
           expect(Stanford::Mods::DateParsing.facet_string_for_early_numeric(example)).to eq expected
         end
       end
@@ -561,7 +561,7 @@ describe "date parsing methods" do
 
   context '*year_via_ruby_parsing' do
     specific_day.each do |example, expected|
-      it "gets #{expected} from #{example}" do
+      it "#{expected} for #{example}" do
         expect(Stanford::Mods::DateParsing.year_via_ruby_parsing(example)).to eq expected
       end
     end
@@ -591,28 +591,28 @@ describe "date parsing methods" do
     skip 'parsed incorrectly' do
       # assigns incorrect values to 13 out of 92 (rest with no val assigned)
       unparseable.each do |example|
-        it "unparseable nil for #{example}" do
+        it "nil for unparseable: #{example}" do
           expect(Stanford::Mods::DateParsing.year_via_ruby_parsing(example)).to eq nil
         end
       end
 
       # assigns incorrect values to 2 out of 2
       brackets_in_middle_of_year.keys.each do |example|
-        it "brackets_in_middle_of_year nil for #{example}" do
+        it "nil for brackets_in_middle_of_year: #{example}" do
           expect(Stanford::Mods::DateParsing.year_via_ruby_parsing(example)).to eq nil
         end
       end
 
       # assigns incorrect values to 3 out of 8 (5 with no val assigned)
       specific_day_2_digit_year.keys.each do |example|
-        it "specific_day_2_digit_year nil for #{example}" do
+        it "nil for specific_day_2_digit_year: #{example}" do
           expect(Stanford::Mods::DateParsing.year_via_ruby_parsing(example)).to eq nil
         end
       end
 
       # assigns incorrect values to 8 out of 8
       decade_only.keys.each do |example|
-        it "decade_only nil for #{example}" do
+        it "nil for decade_only: #{example}" do
           expect(Stanford::Mods::DateParsing.year_via_ruby_parsing(example)).to eq nil
         end
       end

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -372,32 +372,32 @@ describe "date parsing methods" do
     '945' => '0945'
   }
 
-  context '*sortable_year_from_date_str' do
+  context '*sortable_year_for_yyyy' do
     single_year
       .merge(specific_month)
       .merge(specific_day)
       .merge(invalid_but_can_get_year).each do |example, expected|
       it "gets #{expected} from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_date_str(example)).to eq expected
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected
       end
     end
 
     multiple_years.each do |example, expected|
       it "gets #{expected.first} from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_date_str(example)).to eq expected.first
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected.first
       end
     end
 
     specific_day_ruby_parse_fail.each do |example, expected|
       it "gets #{expected} from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_date_str(example)).to eq expected
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected
       end
     end
 
     multiple_years_4_digits_once
       .merge(decade_only_4_digits).each do |example, expected|
       it "gets #{expected} from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_date_str(example)).to eq expected.first
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq expected.first
       end
     end
 
@@ -408,72 +408,72 @@ describe "date parsing methods" do
       .push(*decade_only.keys)
       .push(*century_only.keys).each do |example|
       it "nil for #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_date_str(example)).to eq nil
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yyyy(example)).to eq nil
       end
     end
   end
 
-  context '*sortable_year_from_yy' do
+  context '*sortable_year_for_yy' do
     specific_day_2_digit_year.each do |example, expected|
       it "gets #{expected} from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_yy(example)).to eq expected
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yy(example)).to eq expected
       end
     end
     it '2000 for 12/25/00' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_yy('12/25/00')).to eq '2000'
+      expect(Stanford::Mods::DateParsing.sortable_year_for_yy('12/25/00')).to eq '2000'
     end
     # some strings this method cannot handle (and must be parsed with other class methods)
     it 'nil for yy/mm/dd' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_yy('92/1/31')).to eq nil
+      expect(Stanford::Mods::DateParsing.sortable_year_for_yy('92/1/31')).to eq nil
     end
     it 'nil for yy-dd-mm' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_yy('92-31-1')).to eq nil
+      expect(Stanford::Mods::DateParsing.sortable_year_for_yy('92-31-1')).to eq nil
     end
     decade_only.keys.each do |example|
       it "gets nil from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_yy(example)).to eq nil
+        expect(Stanford::Mods::DateParsing.sortable_year_for_yy(example)).to eq nil
       end
     end
   end
 
-  context '*sortable_year_from_decade' do
+  context '*sortable_year_for_decade' do
     decade_only.each do |example, expected|
       it "gets #{expected.first} from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_decade(example)).to eq expected.first
+        expect(Stanford::Mods::DateParsing.sortable_year_for_decade(example)).to eq expected.first
       end
     end
     it '1990 for 199u' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_decade('199u')).to eq '1990'
+      expect(Stanford::Mods::DateParsing.sortable_year_for_decade('199u')).to eq '1990'
     end
     it '2000 for 200-' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_decade('200-')).to eq '2000'
+      expect(Stanford::Mods::DateParsing.sortable_year_for_decade('200-')).to eq '2000'
     end
     it '2010 for 201?' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_decade('201?')).to eq '2010'
+      expect(Stanford::Mods::DateParsing.sortable_year_for_decade('201?')).to eq '2010'
     end
     it '2020 for 202x' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_decade('202x')).to eq '2020'
+      expect(Stanford::Mods::DateParsing.sortable_year_for_decade('202x')).to eq '2020'
     end
     # some strings this method cannot handle (and must be parsed with other class methods)
     decade_only_4_digits.keys
       .push(*specific_day_2_digit_year.keys).each do |example|
       it "gets nil from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_decade(example)).to eq nil
+        expect(Stanford::Mods::DateParsing.sortable_year_for_decade(example)).to eq nil
       end
     end
   end
 
-  context '*sortable_year_from_century' do
+  context '*sortable_year_for_century' do
     century_only.keys.each do |example|
       it "gets 1700 from #{example}" do
-        expect(Stanford::Mods::DateParsing.sortable_year_from_century(example)).to eq '1700'
+        expect(Stanford::Mods::DateParsing.sortable_year_for_century(example)).to eq '1700'
       end
     end
     it '0700 for 7--' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_century('7--')).to eq '0700'
+      expect(Stanford::Mods::DateParsing.sortable_year_for_century('7--')).to eq '0700'
     end
     it 'nil for 7th century B.C. (to be handled in different method)' do
-      expect(Stanford::Mods::DateParsing.sortable_year_from_century('7th century B.C.')).to eq nil
+      expect(Stanford::Mods::DateParsing.sortable_year_for_century('7th century B.C.')).to eq nil
     end
   end
 
@@ -577,16 +577,16 @@ describe "date parsing methods" do
       end
     end
 
-    # data works via #sortable_year_from_date_str (and don't all work here):
+    # data works via #sortable_year_for_yyyy (and don't all work here):
     #   single_year
     #   specific_month
     #   specific_day_ruby_parse_fail
 
-    # data fails *sortable_year_from_date_str AND for *year_via_ruby_parsing:
+    # data fails *sortable_year_for_yyyy AND for *year_via_ruby_parsing:
     #   multiple_years
     #   century_only
 
-    # data fails *sortable_year_from_date_str
+    # data fails *sortable_year_for_yyyy
     # and partially works for *year_via_ruby_parsing:
     skip 'parsed incorrectly' do
       # assigns incorrect values to 13 out of 92 (rest with no val assigned)

--- a/spec/origin_info_spec.rb
+++ b/spec/origin_info_spec.rb
@@ -15,7 +15,7 @@ describe "computations from /originInfo field" do
     EOF
   end
 
-  context '#date_issued_nodeset' do
+  context '#date_issued_elements' do
     # example string as key, expected num of Elements as value
     {
       '<dateIssued>[1717]</dateIssued><dateIssued encoding="marc">1717</dateIssued>' => 2,
@@ -23,65 +23,162 @@ describe "computations from /originInfo field" do
     }.each do |example, expected|
       describe "for example: #{example}" do
         let(:example) { example }
-        it 'returns Nokogiri NodeSet of Elements matching /originInfo/dateIssued' do
+        it 'returns Array of Nokogiri Elements matching /originInfo/dateIssued' do
           smods_rec.from_str(mods_origin_info)
-          result = smods_rec.date_issued_nodeset
-          expect(result).to be_instance_of(Nokogiri::XML::NodeSet)
+          result = smods_rec.date_issued_elements
+          expect(result).to be_instance_of(Array)
           expect(result.size).to eq expected
           expect(result).to all(be_an(Nokogiri::XML::Element))
         end
       end
     end
+    context 'ignore_approximate=true' do
+      let(:qual_date_val) { '1666' }
+      let(:mods_rec) do
+        <<-EOF
+        #{mods_origin_info_start_str}
+          <dateIssued>2015</dateIssued>
+          <dateIssued qualifier="#{qual_attr_val}">#{qual_date_val}</dateIssued>
+        #{mods_origin_info_end_str}
+        EOF
+      end
+
+      context "removes element when attribute qualifer=" do
+        ['approximate', 'questionable'].each do |attr_val|
+          let(:qual_attr_val) { attr_val }
+          it attr_val do
+            smods_rec.from_str mods_rec
+            result = smods_rec.date_issued_elements(true)
+            expect(result).to be_instance_of(Array)
+            expect(result.size).to eq 1
+            expect(result[0].content).to eq '2015'
+          end
+        end
+      end
+      context "retains element when attribute qualifer=" do
+        ['inferred', 'invalid_attr_val'].each do |attr_val|
+        let(:qual_attr_val) { attr_val }
+          it attr_val do
+            smods_rec.from_str mods_rec
+            result = smods_rec.date_issued_elements(true)
+            expect(result).to be_instance_of(Array)
+            expect(result.size).to eq 2
+            expect(result[0].content).to eq '2015'
+            expect(result[1].content).to eq '1666'
+          end
+        end
+      end
+
+      let(:start_str) {"#{mods_origin_info_start_str}<dateIssued>2015</dateIssued>"}
+      it 'retains element without qualifier attribute"' do
+        m = start_str + '<dateIssued>1666</dateIssued>' + mods_origin_info_end_str
+        smods_rec.from_str m
+        result = smods_rec.date_issued_elements(true)
+        expect(result).to be_instance_of(Array)
+        expect(result.size).to eq 2
+        expect(result[0].content).to eq '2015'
+        expect(result[1].content).to eq '1666'
+      end
+    end
   end
 
-  context '#date_created_nodeset' do
+  context '#date_created_elements' do
     # example string as key, expected num of Elements as value
     {
       '<dateCreated encoding="edtf" keydate="yes" point="start">-0012</dateCreated>
          <dateCreated encoding="edtf" point="end">-0044</dateCreated>' => 2,
       '' => 0
     }.each do |example, expected|
-      describe "for example: #{example}" do
+      describe "for example: '#{example}'" do
         let(:example) { example }
-        it 'returns Nokogiri NodeSet of Elements matching /originInfo/dateCreated' do
+        it 'returns Array of Nokogiri Elements matching /originInfo/dateCreated' do
           smods_rec.from_str(mods_origin_info)
-          result = smods_rec.date_created_nodeset
-          expect(result).to be_instance_of(Nokogiri::XML::NodeSet)
+          result = smods_rec.date_created_elements
+          expect(result).to be_instance_of(Array)
           expect(result.size).to eq expected
           expect(result).to all(be_an(Nokogiri::XML::Element))
         end
       end
     end
+
+    context 'ignore_approximate=true' do
+      let(:qual_date_val) { '1666' }
+      let(:mods_rec) do
+        <<-EOF
+        #{mods_origin_info_start_str}
+          <dateCreated>2015</dateCreated>
+          <dateCreated qualifier="#{qual_attr_val}">#{qual_date_val}</dateCreated>
+        #{mods_origin_info_end_str}
+        EOF
+      end
+
+      context "removes element when attribute qualifer=" do
+        ['approximate', 'questionable'].each do |attr_val|
+          let(:qual_attr_val) { attr_val }
+          it attr_val do
+            smods_rec.from_str mods_rec
+            result = smods_rec.date_created_elements(true)
+            expect(result).to be_instance_of(Array)
+            expect(result.size).to eq 1
+            expect(result[0].content).to eq '2015'
+          end
+        end
+      end
+      context "retains element when attribute qualifer=" do
+        ['inferred', 'invalid_attr_val'].each do |attr_val|
+        let(:qual_attr_val) { attr_val }
+          it attr_val do
+            smods_rec.from_str mods_rec
+            result = smods_rec.date_created_elements(true)
+            expect(result).to be_instance_of(Array)
+            expect(result.size).to eq 2
+            expect(result[0].content).to eq '2015'
+            expect(result[1].content).to eq '1666'
+          end
+        end
+      end
+
+      let(:start_str) {"#{mods_origin_info_start_str}<dateCreated>2015</dateCreated>"}
+      it 'retains element without qualifier attribute"' do
+        m = start_str + '<dateCreated>1666</dateCreated>' + mods_origin_info_end_str
+        smods_rec.from_str m
+        result = smods_rec.date_created_elements(true)
+        expect(result).to be_instance_of(Array)
+        expect(result.size).to eq 2
+        expect(result[0].content).to eq '2015'
+        expect(result[1].content).to eq '1666'
+      end
+    end
   end
 
-  context '#keyDate' do
-    it 'returns nil if passed nodeset is empty' do
+  context '*keyDate' do
+    it 'returns nil if passed Array is empty' do
       mods_str = "#{mods_origin_info_start_str}#{mods_origin_info_end_str}"
       smods_rec.from_str(mods_str)
-      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_nodeset)).to be_nil
+      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_elements)).to be_nil
     end
-    it 'returns nil if passed nodeset has no element with keyDate attribute' do
+    it 'returns nil if passed Array has no element with keyDate attribute' do
       mods_str = "#{mods_origin_info_start_str}<dateIssued>[1738]</dateIssued>#{mods_origin_info_end_str}"
       smods_rec.from_str(mods_str)
-      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_nodeset)).to be_nil
+      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_elements)).to be_nil
     end
-    it 'returns nil if passed nodeset has multiple elements with keyDate attribute' do
+    it 'returns nil if passed Array has multiple elements with keyDate attribute' do
       mods_str = "#{mods_origin_info_start_str}
         <dateIssued>[1968?-</dateIssued>
         <dateIssued encoding='marc' point='start' keyDate='yes'>1968</dateIssued>
         <dateIssued encoding='marc' point='end' keyDate='yes'>9999</dateIssued>
         #{mods_origin_info_end_str}"
       smods_rec.from_str(mods_str)
-      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_nodeset)).to be_nil
+      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_elements)).to be_nil
     end
-    it 'returns single Nokogiri::XML::Element if nodeset has single element with keyDate attribute' do
+    it 'returns single Nokogiri::XML::Element if Arrays has single element with keyDate attribute' do
       mods_str = "#{mods_origin_info_start_str}<dateIssued encoding='w3cdtf' keyDate='yes'>2011</dateIssued>#{mods_origin_info_end_str}"
       smods_rec.from_str(mods_str)
-      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_nodeset)).to be_instance_of(Nokogiri::XML::Element)
+      expect(Stanford::Mods::Record.keyDate(smods_rec.date_issued_elements)).to be_instance_of(Nokogiri::XML::Element)
     end
   end
 
-  context '#remove_approximate' do
+  context '*remove_approximate' do
     it 'removes elements when date_is_approximate? returns true' do
       mods_str = "#{mods_origin_info_start_str}
         <dateIssued>1900</dateIssued>
@@ -89,9 +186,10 @@ describe "computations from /originInfo field" do
         <dateIssued qualifier='questionable'>1930</dateIssued>
         #{mods_origin_info_end_str}"
       smods_rec.from_str(mods_str)
-      nodeset = smods_rec.date_issued_nodeset
-      expect(nodeset.size).to eq 3
-      result = Stanford::Mods::Record.remove_approximate(nodeset)
+      elements = smods_rec.date_issued_elements
+      expect(elements.size).to eq 3
+      result = Stanford::Mods::Record.remove_approximate(elements)
+      expect(result).to be_instance_of(Array)
       expect(result.size).to eq 2
       expect(result.select { |date_el| Stanford::Mods::Record.date_is_approximate?(date_el) }).to eq []
     end
@@ -104,7 +202,7 @@ describe "computations from /originInfo field" do
     it 'false if there is no qualifier attrib' do
       mods_str = "#{mods_origin_info_start_str}<dateIssued>1968</dateIssued>#{mods_origin_info_end_str}"
       smods_rec.from_str(mods_str)
-      date_el = smods_rec.date_issued_nodeset.first
+      date_el = smods_rec.date_issued_elements.first
       expect(Stanford::Mods::Record.date_is_approximate?(date_el)).to eq false
     end
     # value of qualifier attribute as key, expected result as value
@@ -122,7 +220,7 @@ describe "computations from /originInfo field" do
         end
         it "#{expected}" do
           smods_rec.from_str(mods_str)
-          date_el = smods_rec.date_issued_nodeset.first
+          date_el = smods_rec.date_issued_elements.first
           expect(Stanford::Mods::Record.date_is_approximate?(date_el)).to eq expected
         end
       end


### PR DESCRIPTION
- facet_string_from_date_str:  the method that we will use to get single facet values from a date string
- sortable_year_string_from_date_str: gets the sortable String version of the date string.

- implemented ignore_approximate param when getting dateIssued and dateCreated elements -- this will help us choose what we want from a MODS record with multiple dates or with approximate dates to be ignored;   this is the beginnings of the logic to go in the origin_info  file.

It may be easier to review this PR one commit at a time.