### PR TITLE
add pub_year_int method for Integer sorting pub_year values

### DIFF
--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -73,8 +73,6 @@ module Stanford
         sortable_str if sortable_str
       end
 
-      protected :pub_date_best_single_facet_value, :pub_date_best_sort_str_value
-
       # return /originInfo/dateCreated elements in MODS records
       # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute)
       #   should be excluded; false approximate dates should be included

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -201,6 +201,12 @@ module Stanford
       end
 
       # Values for the pub date facet. This is less strict than the 4 year date requirements for pub_date
+      # Jan 2016:  used to populate Solr pub_date field for Spotlight and SearchWorks
+      #   Spotlight:  pub_date field should be replaced by pub_year_w_approx_isi and pub_year_no_approx_isi
+      #   SearchWorks:  pub_date field used for display in search results and show view; for sorting nearby-on-shelf
+      #      these could be done with more approp fields/methods (pub_year_int for sorting;  new pub year methods to populate field)
+      # TODO:  prob should deprecated this in favor of pub_date_facet_single_value;
+      #    need head-to-head testing with pub_date_facet_single_value
       # @return <Array[String]> with values for the pub date facet
       def pub_date_facet
         if pub_date

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -210,15 +210,6 @@ module Stanford
         nil
       end
 
-      # For the date indexing, sorting and faceting, the first place to look is in the dates with encoding=marc array.
-      # If that doesn't exist, look in the dates without encoding=marc array.  Otherwise return nil
-      # @return [Array<String>] values for the date Solr field for this document or nil if none
-      def pub_dates
-        return dates_marc_encoding unless dates_marc_encoding.empty?
-        return dates_no_marc_encoding unless dates_no_marc_encoding.empty?
-        nil
-      end
-
       # creates a date suitable for sorting. Guarnteed to be 4 digits or nil
       # @deprecated:  use pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       def pub_date_sort
@@ -296,6 +287,15 @@ module Stanford
           return @pub_year if @pub_year
         end
         @pub_year = ''
+        nil
+      end
+
+      # For the date indexing, sorting and faceting, the first place to look is in the dates with encoding=marc array.
+      # If that doesn't exist, look in the dates without encoding=marc array.  Otherwise return nil
+      # @return [Array<String>] values for the date Solr field for this document or nil if none
+      def pub_dates
+        return dates_marc_encoding unless dates_marc_encoding.empty?
+        return dates_no_marc_encoding unless dates_no_marc_encoding.empty?
         nil
       end
 

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -259,6 +259,7 @@ module Stanford
       end
 
       # creates a date suitable for sorting. Guarnteed to be 4 digits or nil
+      # @deprecated:  use pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       def pub_date_sort
         if pub_date
           pd = pub_date

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -146,6 +146,7 @@ module Stanford
       # For the date display only, the first place to look is in the dates without encoding=marc array.
       # If no such dates, select the first date in the dates_marc_encoding array.  Otherwise return nil
       # @return [String] value for the pub_date_display Solr field for this document or nil if none
+      # @deprecated:  this is no longer used in SW, Revs or Spotlight Jan 2016
       def pub_date_display
         return dates_no_marc_encoding.first unless dates_no_marc_encoding.empty?
         return dates_marc_encoding.first unless dates_marc_encoding.empty?
@@ -236,7 +237,7 @@ module Stanford
         nil
       end
 
-# ----   old date parsing methods will be deprecated/replaced with new date parsing methods
+# ----   old date parsing methods will be deprecated/replaced with new date parsing methods (see also DateParsing)
 
     protected
 

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -200,34 +200,6 @@ module Stanford
         vals
       end
 
-      # For the date display only, the first place to look is in the dates without encoding=marc array.
-      # If no such dates, select the first date in the dates_marc_encoding array.  Otherwise return nil
-      # @return [String] value for the pub_date_display Solr field for this document or nil if none
-      # @deprecated:  this is no longer used in SW, Revs or Spotlight Jan 2016
-      def pub_date_display
-        return dates_no_marc_encoding.first unless dates_no_marc_encoding.empty?
-        return dates_marc_encoding.first unless dates_marc_encoding.empty?
-        nil
-      end
-
-      # creates a date suitable for sorting. Guarnteed to be 4 digits or nil
-      # @deprecated:  use pub_year_int, or pub_date_sortable_string if you must have a string (why?)
-      def pub_date_sort
-        if pub_date
-          pd = pub_date
-          pd = '0' + pd if pd.length == 3
-          pd = pd.gsub('--', '00')
-        end
-        fail "pub_date_sort was about to return a non 4 digit value #{pd}!" if pd && pd.length != 4
-        pd
-      end
-
-      # The year the object was published, filtered based on max_pub_date and min_pub_date from the config file
-      # @return [String] 4 character year or nil
-      def pub_date
-        pub_year || nil
-      end
-
       # Values for the pub date facet. This is less strict than the 4 year date requirements for pub_date
       # @return <Array[String]> with values for the pub date facet
       def pub_date_facet
@@ -247,11 +219,33 @@ module Stanford
         nil
       end
 
-# ----   old date parsing methods will be deprecated/replaced with new date parsing methods (see also DateParsing)
+      # creates a date suitable for sorting. Guarnteed to be 4 digits or nil
+      # @deprecated:  use pub_year_int, or pub_date_sortable_string if you must have a string (why?)
+      def pub_date_sort
+        if pub_date
+          pd = pub_date
+          pd = '0' + pd if pd.length == 3
+          pd = pd.gsub('--', '00')
+        end
+        fail "pub_date_sort was about to return a non 4 digit value #{pd}!" if pd && pd.length != 4
+        pd
+      end
+
+      # For the date display only, the first place to look is in the dates without encoding=marc array.
+      # If no such dates, select the first date in the dates_marc_encoding array.  Otherwise return nil
+      # @return [String] value for the pub_date_display Solr field for this document or nil if none
+      # @deprecated:  DO NOT USE: this is no longer used in SW, Revs or Spotlight Jan 2016
+      def pub_date_display
+        return dates_no_marc_encoding.first unless dates_no_marc_encoding.empty?
+        return dates_marc_encoding.first unless dates_marc_encoding.empty?
+        nil
+      end
+
+# ----   old date parsing protected methods will be deprecated/replaced with new date parsing methods (see also DateParsing)
 
     protected
 
-      # Get the publish year from mods
+      # The year the object was published
       # @return [String] 4 character year or nil if no valid date was found
       def pub_year
         # use the cached year if there is one
@@ -289,6 +283,7 @@ module Stanford
         @pub_year = ''
         nil
       end
+      alias_method :pub_date, :pub_year
 
       # For the date indexing, sorting and faceting, the first place to look is in the dates with encoding=marc array.
       # If that doesn't exist, look in the dates without encoding=marc array.  Otherwise return nil
@@ -336,7 +331,6 @@ module Stanford
         }
       end
 
-
       def is_number?(object)
         true if Integer(object) rescue false
       end
@@ -344,8 +338,6 @@ module Stanford
       def is_date?(object)
         true if Date.parse(object) rescue false
       end
-
-      # TODO:  need tests for these methods
 
       # get a 4 digit year like 1865 from array of dates
       # @param [Array<String>] dates an array of potential year strings

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -219,45 +219,6 @@ module Stanford
         nil
       end
 
-      # Get the publish year from mods
-      # @return [String] 4 character year or nil if no valid date was found
-      def pub_year
-        # use the cached year if there is one
-        if @pub_year
-          return nil if @pub_year == ''
-          return @pub_year
-        end
-
-        dates = pub_dates
-        if dates
-          pruned_dates = []
-          dates.each do |f_date|
-            # remove ? and []
-            if f_date.length == 4 && f_date.end_with?('?')
-              pruned_dates << f_date.tr('?', '0')
-            else
-              pruned_dates << f_date.delete('?[]')
-            end
-          end
-          # try to find a date starting with the most normal date formats and progressing to more wonky ones
-          @pub_year = get_plain_four_digit_year pruned_dates
-          return @pub_year if @pub_year
-          # Check for years in u notation, e.g., 198u
-          @pub_year = get_u_year pruned_dates
-          return @pub_year if @pub_year
-          @pub_year = get_double_digit_century pruned_dates
-          return @pub_year if @pub_year
-          @pub_year = get_bc_year pruned_dates
-          return @pub_year if @pub_year
-          @pub_year = get_three_digit_year pruned_dates
-          return @pub_year if @pub_year
-          @pub_year = get_single_digit_century pruned_dates
-          return @pub_year if @pub_year
-        end
-        @pub_year = ''
-        nil
-      end
-
       # creates a date suitable for sorting. Guarnteed to be 4 digits or nil
       # @deprecated:  use pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       def pub_date_sort
@@ -298,6 +259,45 @@ module Stanford
 # ----   old date parsing methods will be deprecated/replaced with new date parsing methods (see also DateParsing)
 
     protected
+
+      # Get the publish year from mods
+      # @return [String] 4 character year or nil if no valid date was found
+      def pub_year
+        # use the cached year if there is one
+        if @pub_year
+          return nil if @pub_year == ''
+          return @pub_year
+        end
+
+        dates = pub_dates
+        if dates
+          pruned_dates = []
+          dates.each do |f_date|
+            # remove ? and []
+            if f_date.length == 4 && f_date.end_with?('?')
+              pruned_dates << f_date.tr('?', '0')
+            else
+              pruned_dates << f_date.delete('?[]')
+            end
+          end
+          # try to find a date starting with the most normal date formats and progressing to more wonky ones
+          @pub_year = get_plain_four_digit_year pruned_dates
+          return @pub_year if @pub_year
+          # Check for years in u notation, e.g., 198u
+          @pub_year = get_u_year pruned_dates
+          return @pub_year if @pub_year
+          @pub_year = get_double_digit_century pruned_dates
+          return @pub_year if @pub_year
+          @pub_year = get_bc_year pruned_dates
+          return @pub_year if @pub_year
+          @pub_year = get_three_digit_year pruned_dates
+          return @pub_year if @pub_year
+          @pub_year = get_single_digit_century pruned_dates
+          return @pub_year if @pub_year
+        end
+        @pub_year = ''
+        nil
+      end
 
       # @return [Array<String>] dates from dateIssued and dateCreated tags from origin_info with encoding="marc"
       def dates_marc_encoding

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -223,6 +223,7 @@ module Stanford
       #   http://searchworks-solr-lb.stanford.edu:8983/solr/select?facet.field=format&rows=0&facet.sort=index
       # @return <Array[String]> value in the SearchWorks controlled vocabulary
       # @deprecated - kept for backwards compatibility but not part of SW UI redesign work Summer 2014
+      # @deprecated:  this is no longer used in SW, Revs or Spotlight Jan 2016
       def format
         val = []
         types = self.term_values(:typeOfResource)

--- a/spec/origin_info_spec.rb
+++ b/spec/origin_info_spec.rb
@@ -199,7 +199,7 @@ describe "computations from /originInfo field" do
         '<dateCreated keyDate="yes">180 B.C.</dateCreated>' +
         mods_origin_info_end_str
       smods_rec.from_str(mods_str)
-      expect(smods_rec.send(:pub_date_best_single_facet_value, smods_rec.date_created_elements)).to eq '180 B.C.'
+      expect(smods_rec.pub_date_best_single_facet_value(smods_rec.date_created_elements)).to eq '180 B.C.'
     end
   end
 
@@ -210,7 +210,7 @@ describe "computations from /originInfo field" do
         '<dateCreated keyDate="yes">180 B.C.</dateCreated>' +
         mods_origin_info_end_str
       smods_rec.from_str(mods_str)
-      expect(smods_rec.send(:pub_date_best_sort_str_value, smods_rec.date_created_elements)).to eq '-820'
+      expect(smods_rec.pub_date_best_sort_str_value(smods_rec.date_created_elements)).to eq '-820'
     end
   end
 

--- a/spec/searchworks_format_spec.rb
+++ b/spec/searchworks_format_spec.rb
@@ -8,6 +8,7 @@ describe "Format fields (searchworks.rb)" do
     @ns_decl = "xmlns='#{Mods::MODS_NS}'"
   end
 
+  # @deprecated:  this is no longer used in SW, Revs or Spotlight Jan 2016
   context "format" do
     context "Book:" do
       context "typeOfResource text," do

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -14,79 +14,6 @@ describe "Date methods (searchworks.rb)" do
   # dateCreated:  4 digit year
   #   and they should go in spec/fixtures searchworks_pub_date_data.rb
 
-  context "#pub_date" do
-    it "uses dateCreated if no dateIssued" do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>1904</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1904')
-    end
-    it "gets year from text date" do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>Aug. 3rd, 1886</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1886')
-    end
-    it "ignores question marks and square brackets" do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>Aug. 3rd, [18]86?</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1886')
-    end
-    it '1890 for 1890s' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>early 1890s</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1890')
-    end
-    it 'takes first occurring 4 digit date in string' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>Text dated June 4, 1594; miniatures added by 1596</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1594')
-    end
-    it '1980 for 198u' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued >198u</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1980')
-    end
-    it '19-- for 19uu' do
-      m = "<mods #{ns_decl}>
-      <originInfo>
-        <dateIssued>19uu</dateIssued>
-      </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('19--')
-    end
-    it '-700 for 300 B.C.' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>300 B.C.</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('-700')
-    end
-    it '966 for 966' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>966</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('966')
-    end
-    it '8-- for 9th century' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>9th century</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('8--')
-    end
-  end # pub_date
 
   # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
   context '#pub_date_sort (deprecated)' do
@@ -185,14 +112,13 @@ describe "Date methods (searchworks.rb)" do
     end
   end
 
-  context 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
+  context 'uses dateIssued with marc encoding for sorting and faceting' do
     it '1860' do
       m = "<mods #{ns_decl}><originInfo>
           <dateIssued>1844</dateIssued>
           <dateIssued encoding=\"marc\">1860</dateIssued>
         </originInfo></mods>"
       smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1860')
       expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       expect(smods_rec.pub_date_facet).to eq('1860')
     end
@@ -202,7 +128,6 @@ describe "Date methods (searchworks.rb)" do
           <dateIssued encoding=\"marc\">186?</dateIssued>
         </originInfo></mods>"
       smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1860')
       expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       expect(smods_rec.pub_date_facet).to eq('1860')
     end
@@ -218,6 +143,79 @@ describe "Date methods (searchworks.rb)" do
     end
   end
 
+  context "#pub_date (protected)" do
+    it "uses dateCreated if no dateIssued" do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>1904</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('1904')
+    end
+    it "gets year from text date" do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>Aug. 3rd, 1886</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('1886')
+    end
+    it "ignores question marks and square brackets" do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>Aug. 3rd, [18]86?</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('1886')
+    end
+    it '1890 for 1890s' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>early 1890s</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('1890')
+    end
+    it 'takes first occurring 4 digit date in string' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>Text dated June 4, 1594; miniatures added by 1596</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('1594')
+    end
+    it '1980 for 198u' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued >198u</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('1980')
+    end
+    it '19-- for 19uu' do
+      m = "<mods #{ns_decl}>
+      <originInfo>
+        <dateIssued>19uu</dateIssued>
+      </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('19--')
+    end
+    it '-700 for 300 B.C.' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>300 B.C.</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('-700')
+    end
+    it '966 for 966' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>966</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('966')
+    end
+    it '8-- for 9th century' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>9th century</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_date)).to eq('8--')
+    end
+  end # pub_date
   context "pub_dates (protected)" do
     it "puts dateIssued values before dateCreated values" do
       m = "<mods #{ns_decl}><originInfo>

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -4,6 +4,15 @@ require 'spec_helper'
 describe "Date methods (searchworks.rb)" do
 
   let(:ns_decl) { "xmlns='#{Mods::MODS_NS}'" }
+  let(:smods_rec) { Stanford::Mods::Record.new }
+
+  # NOTE: walters dates are now:
+  # dateIssued:  1500 CE
+  # dateIssued:  15th century CE
+  # dateIssued:  Ca. 1580 CE
+  # or
+  # dateCreated:  4 digit year
+  #   and they should go in spec/fixtures searchworks_pub_date_data.rb
 
   context "pub_dates" do
     it "puts dateIssued values before dateCreated values" do
@@ -18,9 +27,7 @@ describe "Date methods (searchworks.rb)" do
     end
   end
 
-  context "pub_date" do
-    let(:smods_rec) { Stanford::Mods::Record.new }
-
+  context "#pub_date" do
     it "uses dateCreated if no dateIssued" do
       m = "<mods #{ns_decl}><originInfo>
           <dateCreated>1904</dateCreated>
@@ -28,7 +35,7 @@ describe "Date methods (searchworks.rb)" do
       smods_rec.from_str(m)
       expect(smods_rec.pub_date).to eq('1904')
     end
-    it "parses date" do
+    it "gets year from text date" do
       m = "<mods #{ns_decl}><originInfo>
           <dateCreated>Aug. 3rd, 1886</dateCreated>
         </originInfo></mods>"
@@ -42,26 +49,12 @@ describe "Date methods (searchworks.rb)" do
       smods_rec.from_str(m)
       expect(smods_rec.pub_date).to eq('1886')
     end
-    it 'handles an s after the decade' do
+    it '1890 for 1890s' do
       m = "<mods #{ns_decl}><originInfo>
           <dateCreated>early 1890s</dateCreated>
         </originInfo></mods>"
       smods_rec.from_str(m)
       expect(smods_rec.pub_date).to eq('1890')
-    end
-    it 'chooses date ending with CE if there are other choices' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>7192 AM (li-Adam) / 1684 CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1684')
-    end
-    it 'handles 1865-6 (hyphenated range dates)' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>1282 AH / 1865-6 CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1865')
     end
     it 'takes first occurring 4 digit date in string' do
       m = "<mods #{ns_decl}><originInfo>
@@ -70,128 +63,79 @@ describe "Date methods (searchworks.rb)" do
       smods_rec.from_str(m)
       expect(smods_rec.pub_date).to eq('1594')
     end
-    it '3 digit BC dates are "B.C." in pub_date_facet and negative in pub_date_sort, pub_year, and pub_date' do
+    it '1980 for 198u' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued >198u</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('1980')
+    end
+    it '19-- for 19uu' do
+      m = "<mods #{ns_decl}>
+      <originInfo>
+        <dateIssued>19uu</dateIssued>
+      </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('19--')
+    end
+    it '-700 for 300 B.C.' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>300 B.C.</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('-700')
+    end
+    it '966 for 966' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>966</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('966')
+    end
+    it '8-- for 9th century' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>9th century</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('8--')
+    end
+  end # pub_date
+
+  context '#pub_year' do
+    it '-700 for 300 B.C.' do
       m = "<mods #{ns_decl}><originInfo>
           <dateCreated>300 B.C.</dateCreated>
         </originInfo></mods>"
       smods_rec.from_str(m)
       expect(smods_rec.pub_year).to eq('-700')
-      expect(smods_rec.pub_date).to eq('-700')
-      expect(smods_rec.pub_date_sort).to eq('-700')
-      expect(smods_rec.pub_date_facet).to eq('300 B.C.')
     end
-    it '"19th CE" becomes 1800 for pub_date_sort, 19th centruy for pub_date_facet' do
+  end
+
+  context 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
+    it '1860' do
       m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>13th century AH / 19th CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date_facet).to eq('19th century')
-      expect(smods_rec.pub_date_sort).to eq('1800')
-      expect(smods_rec.pub_date).to eq('18--')
-    end
-    it 'takes first of multiple CE dates' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>6 Dhu al-Hijjah 923 AH / 1517 CE -- 7 Rabi I 924 AH / 1518 CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1517')
-      expect(smods_rec.pub_date_sort).to eq('1517')
-      expect(smods_rec.pub_date_facet).to eq('1517')
-    end
-    it 'handles "Late 14th or early 15th century CE" from walters' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>Late 14th or early 15th century CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('14--')
-      expect(smods_rec.pub_date_sort).to eq('1400')
-      expect(smods_rec.pub_date_facet).to eq('15th century')
-    end
-    it 'explicit 3 digit dates have correct pub_date_sort and pub_date_facet' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>966 CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('966')
-      expect(smods_rec.pub_date_sort).to eq('0966')
-      expect(smods_rec.pub_date_facet).to eq('966')
-    end
-    it 'single digit century dates have correct pub_date_sort and pub_date_facet' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>3rd century AH / 9th CE</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('8--')
-      expect(smods_rec.pub_date_sort).to eq('0800')
-      expect(smods_rec.pub_date_facet).to eq('9th century')
-    end
-    it 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>[186-?]</dateIssued><dateIssued encoding=\"marc\">1860</dateIssued>
+          <dateIssued>1844</dateIssued>
+          <dateIssued encoding=\"marc\">1860</dateIssued>
         </originInfo></mods>"
       smods_rec.from_str(m)
       expect(smods_rec.pub_date).to eq('1860')
-      expect(smods_rec.pub_date_sort).to eq('1860')
+      expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       expect(smods_rec.pub_date_facet).to eq('1860')
     end
-    it 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
+    it '186?' do
       m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>1860?]</dateIssued><dateIssued encoding=\"marc\">186?</dateIssued>
+          <dateIssued>1844</dateIssued>
+          <dateIssued encoding=\"marc\">186?</dateIssued>
         </originInfo></mods>"
       smods_rec.from_str(m)
       expect(smods_rec.pub_date).to eq('1860')
-      expect(smods_rec.pub_date_sort).to eq('1860')
+      expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
       expect(smods_rec.pub_date_facet).to eq('1860')
     end
-  end # pub_date
+  end
 
-  context "dates with u notation (198u, 19uu)" do
-    context "single digit u notation (198u)" do
-      let(:smods_rec) do
-        m = "<mods #{ns_decl}>
-        <originInfo>
-          <dateIssued encoding=\"marc\" point=\"start\" keyDate=\"yes\">198u</dateIssued>
-          <dateIssued encoding=\"marc\" point=\"end\">9999</dateIssued>
-        </originInfo></mods>"
-        smr = Stanford::Mods::Record.new
-        smr.from_str(m)
-        smr
-      end
-      it 'pub_date: 198u = 1980' do
-        expect(smods_rec.pub_date).to eq('1980')
-      end
-      it "pub_date_sort: 198u = 1980" do
-        expect(smods_rec.pub_date_sort).to eq('1980')
-      end
-      it "pub_date_facet: 198u = 1980" do
-        expect(smods_rec.pub_date_facet).to eq('1980')
-      end
-    end
-    context "double digit u notation (19uu)" do
-      let(:smods_rec) do
-        m = "<mods #{ns_decl}>
-        <originInfo>
-          <dateIssued encoding=\"marc\" point=\"start\" keyDate=\"yes\">19uu</dateIssued>
-          <dateIssued encoding=\"marc\" point=\"end\">9999</dateIssued>
-        </originInfo></mods>"
-        smr = Stanford::Mods::Record.new
-        smr.from_str(m)
-        smr
-      end
-      it 'pub_date: 19uu = 19--' do
-        expect(smods_rec.pub_date).to eq('19--')
-      end
-      it "pub_date_sort: 19uu = 1900" do
-        expect(smods_rec.pub_date_sort).to eq('1900')
-      end
-      it "pub_date_facet: 19uu = 20th century" do
-        expect(smods_rec.pub_date_facet).to eq('20th century')
-      end
-    end
-  end # u notation
-
-  context 'pub_date_sort' do
-    let(:smods_rec) { Stanford::Mods::Record.new }
+  # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
+  context '#pub_date_sort (deprecated)' do
     it 'four digits' do
       allow(smods_rec).to receive(:pub_date).and_return('1945')
       expect(smods_rec.pub_date_sort).to eq('1945')
@@ -207,6 +151,83 @@ describe "Date methods (searchworks.rb)" do
     it '9--' do
       allow(smods_rec).to receive(:pub_date).and_return('9--')
       expect(smods_rec.pub_date_sort).to eq('0900')
+    end
+    it '1980 for 198u' do
+      m = "<mods #{ns_decl}>
+            <originInfo>
+              <dateIssued>198u</dateIssued>
+            </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_sort).to eq('1980')
+    end
+    it '1900 for 19uu' do
+      m = "<mods #{ns_decl}>
+            <originInfo>
+              <dateIssued>19uu</dateIssued>
+            </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_sort).to eq('1900')
+    end
+    it '-700 for 300 B.C.' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>300 B.C.</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_sort).to eq('-700')
+    end
+    it '0966 for 966' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>966</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_sort).to eq('0966')
+    end
+    it '0800 for 9th century' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>9th century</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_sort).to eq('0800')
+    end
+  end
+
+  context '#pub_date_facet' do
+    it '1980 for 198u' do
+      m = "<mods #{ns_decl}>
+            <originInfo>
+              <dateIssued>198u</dateIssued>
+            </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_facet).to eq('1980')
+    end
+    it '20th century for 19uu' do
+      m = "<mods #{ns_decl}>
+            <originInfo>
+              <dateIssued>19uu</dateIssued>
+            </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_facet).to eq('20th century')
+    end
+    it '3000 B.C. for 300 B.C.' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>300 B.C.</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_facet).to eq('300 B.C.')
+    end
+    it '966 for 966' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>966</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_facet).to eq('966')
+    end
+    it '9th century for 9th century' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>9th century</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date_facet).to eq('9th century')
     end
   end
 

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -14,19 +14,6 @@ describe "Date methods (searchworks.rb)" do
   # dateCreated:  4 digit year
   #   and they should go in spec/fixtures searchworks_pub_date_data.rb
 
-  context "pub_dates" do
-    it "puts dateIssued values before dateCreated values" do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>1904</dateCreated>
-          <dateCreated>1904</dateCreated>
-          <dateIssued>1906</dateIssued>
-        </originInfo></mods>"
-      smods_rec = Stanford::Mods::Record.new
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_dates).to eq(['1906', '1904', '1904'])
-    end
-  end
-
   context "#pub_date" do
     it "uses dateCreated if no dateIssued" do
       m = "<mods #{ns_decl}><originInfo>
@@ -100,39 +87,6 @@ describe "Date methods (searchworks.rb)" do
       expect(smods_rec.pub_date).to eq('8--')
     end
   end # pub_date
-
-  context '#pub_year (protected)' do
-    it '-700 for 300 B.C.' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateCreated>300 B.C.</dateCreated>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.send(:pub_year)).to eq('-700')
-    end
-  end
-
-  context 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
-    it '1860' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>1844</dateIssued>
-          <dateIssued encoding=\"marc\">1860</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1860')
-      expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
-      expect(smods_rec.pub_date_facet).to eq('1860')
-    end
-    it '186?' do
-      m = "<mods #{ns_decl}><originInfo>
-          <dateIssued>1844</dateIssued>
-          <dateIssued encoding=\"marc\">186?</dateIssued>
-        </originInfo></mods>"
-      smods_rec.from_str(m)
-      expect(smods_rec.pub_date).to eq('1860')
-      expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
-      expect(smods_rec.pub_date_facet).to eq('1860')
-    end
-  end
 
   # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
   context '#pub_date_sort (deprecated)' do
@@ -228,6 +182,52 @@ describe "Date methods (searchworks.rb)" do
         </originInfo></mods>"
       smods_rec.from_str(m)
       expect(smods_rec.pub_date_facet).to eq('9th century')
+    end
+  end
+
+  context 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
+    it '1860' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>1844</dateIssued>
+          <dateIssued encoding=\"marc\">1860</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('1860')
+      expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
+      expect(smods_rec.pub_date_facet).to eq('1860')
+    end
+    it '186?' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateIssued>1844</dateIssued>
+          <dateIssued encoding=\"marc\">186?</dateIssued>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.pub_date).to eq('1860')
+      expect(smods_rec.pub_date_sort).to eq('1860') # @deprecated:  need to switch to pub_year_int, or pub_date_sortable_string if you must have a string (why?)
+      expect(smods_rec.pub_date_facet).to eq('1860')
+    end
+  end
+
+  context '#pub_year (protected)' do
+    it '-700 for 300 B.C.' do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>300 B.C.</dateCreated>
+        </originInfo></mods>"
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_year)).to eq('-700')
+    end
+  end
+
+  context "pub_dates (protected)" do
+    it "puts dateIssued values before dateCreated values" do
+      m = "<mods #{ns_decl}><originInfo>
+          <dateCreated>1904</dateCreated>
+          <dateCreated>1904</dateCreated>
+          <dateIssued>1906</dateIssued>
+        </originInfo></mods>"
+      smods_rec = Stanford::Mods::Record.new
+      smods_rec.from_str(m)
+      expect(smods_rec.send(:pub_dates)).to eq(['1906', '1904', '1904'])
     end
   end
 

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -125,22 +125,20 @@ describe "Date methods (searchworks.rb)" do
       expect(smods_rec.pub_date_sort).to eq('0800')
       expect(smods_rec.pub_date_facet).to eq('9th century')
     end
-    it 'uses dateIssued without marc encoding for pub_date_display and the one with marc encoding for indexing, sorting and faceting' do
+    it 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
       m = "<mods #{ns_decl}><originInfo>
           <dateIssued>[186-?]</dateIssued><dateIssued encoding=\"marc\">1860</dateIssued>
         </originInfo></mods>"
       smods_rec.from_str(m)
-      expect(smods_rec.pub_date_display).to eq('[186-?]')
       expect(smods_rec.pub_date).to eq('1860')
       expect(smods_rec.pub_date_sort).to eq('1860')
       expect(smods_rec.pub_date_facet).to eq('1860')
     end
-    it 'uses dateIssued without marc encoding for pub_date_display and the one with marc encoding for indexing, sorting and faceting' do
+    it 'uses dateIssued with marc encoding for indexing, sorting and faceting' do
       m = "<mods #{ns_decl}><originInfo>
           <dateIssued>1860?]</dateIssued><dateIssued encoding=\"marc\">186?</dateIssued>
         </originInfo></mods>"
       smods_rec.from_str(m)
-      expect(smods_rec.pub_date_display).to eq('1860?]')
       expect(smods_rec.pub_date).to eq('1860')
       expect(smods_rec.pub_date_sort).to eq('1860')
       expect(smods_rec.pub_date_facet).to eq('1860')

--- a/spec/searchworks_pub_dates_spec.rb
+++ b/spec/searchworks_pub_dates_spec.rb
@@ -101,13 +101,13 @@ describe "Date methods (searchworks.rb)" do
     end
   end # pub_date
 
-  context '#pub_year' do
+  context '#pub_year (protected)' do
     it '-700 for 300 B.C.' do
       m = "<mods #{ns_decl}><originInfo>
           <dateCreated>300 B.C.</dateCreated>
         </originInfo></mods>"
       smods_rec.from_str(m)
-      expect(smods_rec.pub_year).to eq('-700')
+      expect(smods_rec.send(:pub_year)).to eq('-700')
     end
   end
 


### PR DESCRIPTION
Also:
* made (old) methods not called directly by SW, Spotlight, Revs, or other protected:
  * pub_year
  * pub_date
  * pub_dates
* pub_date_best_sort_str_value and pub_date_best_single_facet_value are now public methods, not protected   (b/c they are used in gdor-indexer)
* deprecated methods:  
  * format
  * pub_date_display
  * pub_date_sort