### PR TITLE
pub_year_display_str  implemented

### DIFF
--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -58,7 +58,9 @@ module Stanford
         return if orig_date_str == '0000-00-00' # shpc collection has these useless dates
         # B.C. first in case there are 4 digits, e.g. 1600 B.C.
         return display_str_for_bc if orig_date_str.match(BC_REGEX)
-        result = sortable_year_for_yyyy_yy_or_decade
+        # decade next in case there are 4 digits, e.g. 1950s
+        return display_str_for_decade if orig_date_str.match(DECADE_4CHAR_REGEXP) || orig_date_str.match(DECADE_S_REGEXP)
+        result = sortable_year_for_yyyy_or_yy
         unless result
           # try removing brackets between digits in case we have 169[5] or [18]91
           no_brackets = remove_brackets
@@ -80,7 +82,8 @@ module Stanford
         return if orig_date_str == '0000-00-00' # shpc collection has these useless dates
         # B.C. first in case there are 4 digits, e.g. 1600 B.C.
         return sortable_year_int_for_bc if orig_date_str.match(BC_REGEX)
-        result = sortable_year_for_yyyy_yy_or_decade
+        result = sortable_year_for_yyyy_or_yy
+        result ||= sortable_year_for_decade # 19xx or 20xx
         result ||= sortable_year_for_century
         result ||= sortable_year_int_for_early_numeric
         unless result
@@ -100,7 +103,8 @@ module Stanford
         return if orig_date_str == '0000-00-00' # shpc collection has these useless dates
         # B.C. first in case there are 4 digits, e.g. 1600 B.C.
         return sortable_year_str_for_bc if orig_date_str.match(BC_REGEX)
-        result = sortable_year_for_yyyy_yy_or_decade
+        result = sortable_year_for_yyyy_or_yy
+        result ||= sortable_year_for_decade # 19xx or 20xx
         result ||= sortable_year_for_century
         result ||= sortable_year_str_for_early_numeric
         unless result
@@ -114,11 +118,10 @@ module Stanford
       # get String sortable value year if we can parse date_str to get a year.
       # @return [String, nil] String sortable year if we could parse one, nil otherwise
       #  note that these values must *lexically* sort to create a chronological sort.
-      def sortable_year_for_yyyy_yy_or_decade
+      def sortable_year_for_yyyy_or_yy
         # most date strings have a four digit year
         result = sortable_year_for_yyyy
         result ||= sortable_year_for_yy # 19xx or 20xx
-        result ||= sortable_year_for_decade # 19xx or 20xx
         result
       end
 

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -262,9 +262,9 @@ module Stanford
       def display_str_for_early_numeric
         return unless orig_date_str.match(EARLY_NUMERIC)
         # negative number becomes B.C.
-        return orig_date_str[1..-1] + " B.C." if orig_date_str.match(/^\-/)
+        return  "#{orig_date_str[1..-1]} B.C." if orig_date_str.match(/^\-/)
         # remove leading 0s from early dates
-        orig_date_str.to_i.to_s
+        "#{orig_date_str.to_i} A.D."
       end
 
       # NOTE:  while Date.parse() works for many dates, the *sortable_year_for_yyyy

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -57,7 +57,7 @@ module Stanford
       def date_str_for_display
         return if orig_date_str == '0000-00-00' # shpc collection has these useless dates
         # B.C. first in case there are 4 digits, e.g. 1600 B.C.
-        return facet_string_for_bc if orig_date_str.match(BC_REGEX)
+        return display_str_for_bc if orig_date_str.match(BC_REGEX)
         result = sortable_year_for_yyyy_yy_or_decade
         unless result
           # try removing brackets between digits in case we have 169[5] or [18]91
@@ -66,8 +66,8 @@ module Stanford
         end
         # parsing below this line gives string inapprop for year_str_valid?
         unless self.class.year_str_valid?(result)
-          result = facet_string_for_century
-          result ||= facet_string_for_early_numeric
+          result = display_str_for_century
+          result ||= display_str_for_early_numeric
         end
         # remove leading 0s from early dates
         result = result.to_i.to_s if result && result.match(/^\d+$/)
@@ -188,10 +188,10 @@ module Stanford
         end
       end
 
-      # get single facet value for century (17th century) if we have:  yyuu, yy--, yy--? or xxth century pattern
+      # get display value for century (17th century) if we have:  yyuu, yy--, yy--? or xxth century pattern
       #   note that these are the only century patterns found in our actual date strings in MODS records
       # @return [String, nil] yy(th) Century if orig_date_str matches pattern, nil otherwise; also nil if B.C. in pattern
-      def facet_string_for_century
+      def display_str_for_century
         return unless orig_date_str
         return if orig_date_str.match(/B\.C\./)
         century_str_matches = orig_date_str.match(CENTURY_WORD_REGEXP)
@@ -224,9 +224,9 @@ module Stanford
         "-#{$1}".to_i if bc_matches
       end
 
-      # get single facet value for B.C. if we have  B.C. pattern
+      # get display value for B.C. if we have  B.C. pattern
       # @return [String, nil] ddd B.C.  if ddd B.C. in pattern; nil otherwise
-      def facet_string_for_bc
+      def display_str_for_bc
         bc_matches = orig_date_str.match(BC_REGEX) if orig_date_str
         bc_matches.to_s if bc_matches
       end
@@ -257,9 +257,9 @@ module Stanford
         orig_date_str.to_i if orig_date_str.match(/^-\d{4}$/)
       end
 
-      # get single facet value for date String containing yyy, yy, y, -y, -yy, -yyy
+      # get display value for date String containing yyy, yy, y, -y, -yy, -yyy
       #   negative number strings will be changed to B.C. strings
-      def facet_string_for_early_numeric
+      def display_str_for_early_numeric
         return unless orig_date_str.match(EARLY_NUMERIC)
         # negative number becomes B.C.
         return orig_date_str[1..-1] + " B.C." if orig_date_str.match(/^\-/)

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -157,13 +157,32 @@ module Stanford
         nil # explicitly want nil if date won't parse
       end
 
+      DECADE_4CHAR_REGEXP = Regexp.new('(^|\D)\d{3}[u\-?x]')
+
       # get first year of decade (as String) if we have:  yyyu, yyy-, yyy? or yyyx pattern
       #   note that these are the only decade patterns found in our actual date strings in MODS records
       # @return [String, nil] 4 digit year (e.g. 1860, 1950) if orig_date_str matches pattern, nil otherwise
       def sortable_year_for_decade
-        decade_matches = orig_date_str.match(/\d{3}[u\-?x]/) if orig_date_str
+        decade_matches = orig_date_str.match(DECADE_4CHAR_REGEXP) if orig_date_str
         changed_to_zero = decade_matches.to_s.tr('u\-?x', '0') if decade_matches
         DateParsing.new(changed_to_zero).sortable_year_for_yyyy if changed_to_zero
+      end
+
+      DECADE_S_REGEXP = Regexp.new('\d{3}0\'?s')
+
+      # get, e.g. 1950s, if we have:  yyyu, yyy-, yyy? or yyyx pattern or  yyy0s or yyy0's
+      #   note that these are the only decade patterns found in our actual date strings in MODS records
+      # @return [String, nil] 4 digit year with s (e.g. 1860s, 1950s) if orig_date_str matches pattern, nil otherwise
+      def display_str_for_decade
+        decade_matches = orig_date_str.match(DECADE_4CHAR_REGEXP) if orig_date_str
+        if decade_matches
+          changed_to_zero = decade_matches.to_s.tr('u\-?x', '0') if decade_matches
+          zeroth_year = DateParsing.new(changed_to_zero).sortable_year_for_yyyy if changed_to_zero
+          return "#{zeroth_year}s" if zeroth_year
+        else
+          decade_matches = orig_date_str.match(DECADE_S_REGEXP) if orig_date_str
+          return decade_matches.to_s.tr("'", '') if decade_matches
+        end
       end
 
       CENTURY_WORD_REGEXP = Regexp.new('(\d{1,2}).*century')

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -70,7 +70,7 @@ module Stanford
           result ||= display_str_for_early_numeric
         end
         # remove leading 0s from early dates
-        result = result.to_i.to_s if result && result.match(/^\d+$/)
+        result = "#{result.to_i} A.D." if result && result.match(/^0\d+$/)
         result
       end
 

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -7,16 +7,13 @@ module Stanford
     #     - we could add methods like my_date.bc?
     class DateParsing
 
-      # get single facet value for date, generally an explicit year or "17th century" or "5 B.C."
-      #   returns '845', not 0845
-      # @param [String] date_str String containing a date (we hope)
-      # @return [String, nil] String facet value for year if we could parse one, nil otherwise
-      def self.facet_string_from_date_str(date_str)
-        DateParsing.new(date_str).facet_string_from_date_str
+      # get display value for year, generally an explicit year or "17th century" or "5 B.C." or "1950s" or '845 A.D.'
+      # @return [String, nil] display value for year if we could parse one, nil otherwise
+      def self.date_str_for_display(date_str)
+        DateParsing.new(date_str).date_str_for_display
       end
 
       # get year as Integer if we can parse date_str to get a year.
-      # @param [String] date_str String containing a date (we hope)
       # @return [Integer, nil] Integer year if we could parse one, nil otherwise
       def self.year_int_from_date_str(date_str)
         DateParsing.new(date_str).year_int_from_date_str
@@ -25,7 +22,6 @@ module Stanford
       # get String sortable value year if we can parse date_str to get a year.
       #   SearchWorks currently uses a string field for pub date sorting; thus so does Spotlight.
       #   The values returned must *lexically* sort in chronological order, so the B.C. dates are tricky
-      # @param [String] date_str String containing a date (we hope)
       # @return [String, nil] String sortable year if we could parse one, nil otherwise
       #  note that these values must *lexically* sort to create a chronological sort.
       def self.sortable_year_string_from_date_str(date_str)
@@ -56,9 +52,9 @@ module Stanford
 
       BRACKETS_BETWEEN_DIGITS_REXEXP = Regexp.new('\d[' + Regexp.escape('[]') + ']\d')
 
-      # get single facet value for date, generally an explicit year or "17th century" or "5 B.C."
-      # @return [String, nil] String facet value for year if we could parse one, nil otherwise
-      def facet_string_from_date_str
+      # get display value for year, generally an explicit year or "17th century" or "5 B.C." or "1950s" or '845 A.D.'
+      # @return [String, nil] String value for year if we could parse one, nil otherwise
+      def date_str_for_display
         return if orig_date_str == '0000-00-00' # shpc collection has these useless dates
         # B.C. first in case there are 4 digits, e.g. 1600 B.C.
         return facet_string_for_bc if orig_date_str.match(BC_REGEX)
@@ -66,7 +62,7 @@ module Stanford
         unless result
           # try removing brackets between digits in case we have 169[5] or [18]91
           no_brackets = remove_brackets
-          return DateParsing.new(no_brackets).facet_string_from_date_str if no_brackets
+          return DateParsing.new(no_brackets).date_str_for_display if no_brackets
         end
         # parsing below this line gives string inapprop for year_str_valid?
         unless self.class.year_str_valid?(result)

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -4,23 +4,13 @@ require 'mods'
 # Parsing MODS /originInfo for Publication/Imprint data:
 #  * pub year for date slider facet
 #  * pub year for sorting
-#  * pub year for single facet value
+#  * pub year for single display value
 #  * imprint info for display
 #  *
 # These methods may be used by searchworks.rb file or by downstream apps
 module Stanford
   module Mods
     class Record < ::Mods::Record
-
-      # return a single string intended for facet use for pub date
-      # prefer dateIssued (any) before dateCreated (any) before dateCaptured (any)
-      #  look for a keyDate and use it if there is one;  otherwise pick earliest date
-      # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute)
-      #   should be ignored; false if approximate dates should be included
-      # @return [String] single String containing publication year for facet use
-      def pub_date_facet_single_value(ignore_approximate = false)
-        single_pub_year(ignore_approximate, :year_facet_str)
-      end
 
       # return pub year as an Integer
       # prefer dateIssued (any) before dateCreated (any) before dateCaptured (any)
@@ -45,11 +35,49 @@ module Stanford
         single_pub_year(ignore_approximate, :year_sort_str)
       end
 
+      # return a single string intended for display of pub year
+      # 0 < year < 1000:  add A.D. suffix
+      # year < 0:  add B.C. suffix.  ('-5'  =>  '5 B.C.', '700 B.C.'  => '700 B.C.')
+      # 195u =>  195x
+      # 19uu => 19xx
+      #   '-5'  =>  '5 B.C.'
+      #   '700 B.C.'  => '700 B.C.'
+      #   '7th century' => '7th century'
+      # date ranges?
+      # prefer dateIssued (any) before dateCreated (any) before dateCaptured (any)
+      #  look for a keyDate and use it if there is one;  otherwise pick earliest date
+      # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute)
+      #   should be ignored; false if approximate dates should be included
+      def pub_year_display_str(ignore_approximate = false)
+        single_pub_year(ignore_approximate, :year_display_str)
+
+        # TODO: want range displayed when start and end points
+        # TODO: also want best year in year_isi fields
+        # get_main_title_date
+        # https://github.com/sul-dlss/SearchWorks/blob/7d4d870a9d450fed8b081c38dc3dbd590f0b706e/app/helpers/results_document_helper.rb#L8-L46
+
+        #"publication_year_isi"   => "Publication date",  <--  do it already
+        #"beginning_year_isi"     => "Beginning date",
+        #"earliest_year_isi"      => "Earliest date",
+        #"earliest_poss_year_isi" => "Earliest possible date",
+        #"ending_year_isi"        => "Ending date",
+        #"latest_year_isi"        => "Latest date",
+        #"latest_poss_year_isi"   => "Latest possible date",
+        #"production_year_isi"    => "Production date",
+        #"original_year_isi"      => "Original date",
+        #"copyright_year_isi"     => "Copyright date"} %>
+
+        #"creation_year_isi"      => "Creation date",  <--  do it already
+        #{}"release_year_isi"       => "Release date",
+        #{}"reprint_year_isi"       => "Reprint/reissue date",
+        #{}"other_year_isi"         => "Date",
+      end
+
       # given the passed date elements, look for a single keyDate and use it if there is one;
       #    otherwise pick earliest parseable date
       # @param [Array<Nokogiri::XML::Element>] date_el_array the elements from which to select a pub date
-      # @return [String] single String containing publication year for facet use
-      def year_facet_str(date_el_array)
+      # @return [String] single String containing publication year for display
+      def year_display_str(date_el_array)
         result = date_parsing_result(date_el_array, :date_str_for_display)
         return result if result
         _ignore, orig_str_to_parse = self.class.earliest_year_str(date_el_array)
@@ -205,8 +233,8 @@ module Stanford
       #   Spotlight:  pub_date field should be replaced by pub_year_w_approx_isi and pub_year_no_approx_isi
       #   SearchWorks:  pub_date field used for display in search results and show view; for sorting nearby-on-shelf
       #      these could be done with more approp fields/methods (pub_year_int for sorting;  new pub year methods to populate field)
-      # TODO:  prob should deprecated this in favor of pub_date_facet_single_value;
-      #    need head-to-head testing with pub_date_facet_single_value
+      # TODO:  prob should deprecate this in favor of pub_year_display_str;
+      #    need head-to-head testing with pub_year_display_str
       # @return <Array[String]> with values for the pub date facet
       def pub_date_facet
         if pub_date

--- a/lib/stanford-mods/origin_info.rb
+++ b/lib/stanford-mods/origin_info.rb
@@ -50,10 +50,10 @@ module Stanford
       # @param [Array<Nokogiri::XML::Element>] date_el_array the elements from which to select a pub date
       # @return [String] single String containing publication year for facet use
       def year_facet_str(date_el_array)
-        result = date_parsing_result(date_el_array, :facet_string_from_date_str)
+        result = date_parsing_result(date_el_array, :date_str_for_display)
         return result if result
         _ignore, orig_str_to_parse = self.class.earliest_year_str(date_el_array)
-        DateParsing.facet_string_from_date_str(orig_str_to_parse) if orig_str_to_parse
+        DateParsing.date_str_for_display(orig_str_to_parse) if orig_str_to_parse
       end
 
       # given the passed date elements, look for a single keyDate and use it if there is one;

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -417,6 +417,7 @@ describe "date parsing methods" do
       .merge(brackets_in_middle_of_year)
       .merge(invalid_but_can_get_year).each do |example, expected|
       expected = expected.to_i.to_s if expected.match(/^\d+$/)
+      expected = "#{expected} A.D." if expected.match(/^\d{1,3}$/)
       it "#{expected} for single value #{example}" do
         expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected
       end
@@ -438,7 +439,7 @@ describe "date parsing methods" do
           expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq exp
         end
       else
-        expected = "#{expected.to_i.to_s} A.D." if expected.match(/^\d+$/)
+        expected = "#{expected.to_i} A.D." if expected.match(/^\d+$/)
         it "#{expected} for #{example}" do
           expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected
         end

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -388,10 +388,10 @@ describe "date parsing methods" do
     '8 B.C.' => -8
   }
 
-  context '*facet_string_from_date_str' do
-    it 'calls instance method facet_string_from_date_str' do
-      expect_any_instance_of(Stanford::Mods::DateParsing).to receive(:facet_string_from_date_str)
-      Stanford::Mods::DateParsing.facet_string_from_date_str('1666')
+  context '*date_str_for_display' do
+    it 'calls instance method date_str_for_display' do
+      expect_any_instance_of(Stanford::Mods::DateParsing).to receive(:date_str_for_display)
+      Stanford::Mods::DateParsing.date_str_for_display('1666')
     end
   end
   context '*sortable_year_string_from_date_str' do
@@ -407,7 +407,7 @@ describe "date parsing methods" do
     end
   end
 
-  context '#facet_string_from_date_str' do
+  context '#date_str_for_display' do
     single_year
       .merge(specific_month)
       .merge(specific_day)
@@ -418,7 +418,7 @@ describe "date parsing methods" do
       .merge(invalid_but_can_get_year).each do |example, expected|
       expected = expected.to_i.to_s if expected.match(/^\d+$/)
       it "#{expected} for single value #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_from_date_str).to eq expected
+        expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected
       end
     end
 
@@ -427,7 +427,7 @@ describe "date parsing methods" do
       .merge(decade_only)
       .merge(decade_only_4_digits).each do |example, expected|
       it "#{expected.first} for multi-value #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_from_date_str).to eq expected.first
+        expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected.first
       end
     end
 
@@ -435,23 +435,23 @@ describe "date parsing methods" do
       if example.start_with?('-')
         exp = example[1..-1] + " B.C."
         it "#{exp} for #{example}" do
-          expect(Stanford::Mods::DateParsing.new(example).facet_string_from_date_str).to eq exp
+          expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq exp
         end
       else
         expected = expected.to_i.to_s if expected.match(/^\d+$/)
         it "#{expected} for #{example}" do
-          expect(Stanford::Mods::DateParsing.new(example).facet_string_from_date_str).to eq expected
+          expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected
         end
       end
     end
 
     bc_dates.keys.each do |example|
       it "#{example} for #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_from_date_str).to eq example
+        expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq example
       end
     end
     it '1600 B.C. for 1600 B.C.' do
-      expect(Stanford::Mods::DateParsing.new('1600 B.C.').facet_string_from_date_str).to eq '1600 B.C.'
+      expect(Stanford::Mods::DateParsing.new('1600 B.C.').date_str_for_display).to eq '1600 B.C.'
     end
 
     [ # bad dates
@@ -461,7 +461,7 @@ describe "date parsing methods" do
       'uuuu'
     ].each do |example|
       it "nil for #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_from_date_str).to eq nil
+        expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq nil
       end
     end
   end

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -702,6 +702,34 @@ describe "date parsing methods" do
     end
   end
 
+  context '#display_str_for_decade' do
+    decade_only.each do |example, expected|
+      it "#{expected.first} for #{example}" do
+        expect(Stanford::Mods::DateParsing.new(example).display_str_for_decade).to eq "#{expected.first}s"
+      end
+    end
+    { # example string as key, expected result as value
+      '199u' => '1990s',
+      '200-' => '2000s',
+      '201?' => '2010s',
+      '202x' => '2020s',
+      'early 1890s' => '1890s',
+      '1950s' => '1950s',
+      "1950's" => '1950s'
+    }.each do |example, expected|
+      it "#{expected} for #{example}" do
+        expect(Stanford::Mods::DateParsing.new(example).display_str_for_decade).to eq expected
+      end
+    end
+
+    # some of the strings this method cannot handle (so must be parsed with other instance methods)
+    specific_day_2_digit_year.keys.each do |example|
+      it "nil for #{example}" do
+        expect(Stanford::Mods::DateParsing.new(example).display_str_for_decade).to eq nil
+      end
+    end
+  end
+
   context '#sortable_year_for_century' do
     century_only.keys.each do |example|
       it "1700 from #{example}" do

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -423,10 +423,16 @@ describe "date parsing methods" do
       end
     end
 
-    multiple_years
-      .merge(multiple_years_4_digits_once)
-      .merge(decade_only)
+    decade_only
       .merge(decade_only_4_digits).each do |example, expected|
+      expected = "#{expected.first.to_i}s" if expected.first.match(/^\d+$/)
+      it "#{expected} for decade #{example}" do
+        expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected
+      end
+    end
+
+    multiple_years
+      .merge(multiple_years_4_digits_once).each do |example, expected|
       it "#{expected.first} for multi-value #{example}" do
         expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected.first
       end

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -433,12 +433,12 @@ describe "date parsing methods" do
 
     early_numeric_dates.each do |example, expected|
       if example.start_with?('-')
-        exp = example[1..-1] + " B.C."
+        exp = "#{example[1..-1]} B.C."
         it "#{exp} for #{example}" do
           expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq exp
         end
       else
-        expected = expected.to_i.to_s if expected.match(/^\d+$/)
+        expected = "#{expected.to_i.to_s} A.D." if expected.match(/^\d+$/)
         it "#{expected} for #{example}" do
           expect(Stanford::Mods::DateParsing.new(example).date_str_for_display).to eq expected
         end
@@ -766,7 +766,7 @@ describe "date parsing methods" do
       else
         exp = "#{expected} A.D."
         it "#{expected} for #{example}" do
-          expect(Stanford::Mods::DateParsing.new(example).display_str_for_early_numeric).to eq expected
+          expect(Stanford::Mods::DateParsing.new(example).display_str_for_early_numeric).to eq exp
         end
       end
     end

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -715,10 +715,10 @@ describe "date parsing methods" do
     end
   end
 
-  context '#facet_string_for_century' do
+  context '#display_str_for_century' do
     century_only.each do |example, expected|
       it "#{expected} for #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_for_century).to eq expected
+        expect(Stanford::Mods::DateParsing.new(example).display_str_for_century).to eq expected
       end
     end
     { # example string as key, expected result as value
@@ -730,12 +730,12 @@ describe "date parsing methods" do
       '2--' => '3rd century'
     }.each do |example, expected|
       it "#{expected} for #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_for_century).to eq expected
+        expect(Stanford::Mods::DateParsing.new(example).display_str_for_century).to eq expected
       end
     end
 
     it 'nil for 7th century B.C. (to be handled in different method)' do
-      expect(Stanford::Mods::DateParsing.new('7th century B.C.').facet_string_for_century).to eq nil
+      expect(Stanford::Mods::DateParsing.new('7th century B.C.').display_str_for_century).to eq nil
     end
   end
 
@@ -755,17 +755,18 @@ describe "date parsing methods" do
     end
   end
 
-  context '#facet_string_for_early_numeric' do
+  context '#display_str_for_early_numeric' do
     early_numeric_dates.each do |example, expected|
       expected = expected.to_i.to_s if expected.match(/^\d+$/)
       if example.start_with?('-')
-        exp = example[1..-1] + " B.C."
+        exp = "#{example[1..-1]} B.C."
         it "#{exp} for #{example}" do
-          expect(Stanford::Mods::DateParsing.new(example).facet_string_for_early_numeric).to eq exp
+          expect(Stanford::Mods::DateParsing.new(example).display_str_for_early_numeric).to eq exp
         end
       else
+        exp = "#{expected} A.D."
         it "#{expected} for #{example}" do
-          expect(Stanford::Mods::DateParsing.new(example).facet_string_for_early_numeric).to eq expected
+          expect(Stanford::Mods::DateParsing.new(example).display_str_for_early_numeric).to eq expected
         end
       end
     end
@@ -787,14 +788,14 @@ describe "date parsing methods" do
     end
   end
 
-  context '#facet_string_for_bc' do
+  context '#display_str_for_bc' do
     bc_dates.keys.each do |example|
       it "#{example} for #{example}" do
-        expect(Stanford::Mods::DateParsing.new(example).facet_string_for_bc).to eq example
+        expect(Stanford::Mods::DateParsing.new(example).display_str_for_bc).to eq example
       end
     end
     it '1600 B.C. for 1600 B.C.' do
-      expect(Stanford::Mods::DateParsing.new('1600 B.C.').facet_string_for_bc).to eq '1600 B.C.'
+      expect(Stanford::Mods::DateParsing.new('1600 B.C.').display_str_for_bc).to eq '1600 B.C.'
     end
   end
 

--- a/spec/fixtures/searchworks_pub_date_data.rb
+++ b/spec/fixtures/searchworks_pub_date_data.rb
@@ -1,0 +1,932 @@
+# fixture data from real MODS from prod purl pages for data in or soon to be in prod SearchWorks
+
+mods_origin_info_start_str = "<mods xmlns=\"#{Mods::MODS_NS}\"><originInfo>"
+mods_origin_info_end_str = '</originInfo></mods>'
+
+SEARCHWORKS_PUB_DATE_DATA = {
+  'batchelor' =>
+    { # key is mods_xml;  values = [pub year int, pub years display str]
+      # ct961sj2730 coll rec:  no originInfo dates)
+      # dr330jt7122
+      mods_origin_info_start_str +
+        '<dateIssued>1843</dateIssued>' +
+        mods_origin_info_end_str => [1843, '1843'],
+      # jg216qn0081
+      mods_origin_info_start_str +
+        '<dateIssued>12th May 1800</dateIssued>' +
+        '<dateIssued encoding="marc">1800</dateIssued>' +
+        mods_origin_info_end_str => [1800, '1800'],
+      # sx557zn4953
+      mods_origin_info_start_str +
+        '<dateIssued>1570</dateIssued>' +
+        mods_origin_info_end_str => [1570, '1570'],
+      # mb505bx7548
+      mods_origin_info_start_str +
+        '<dateIssued>15 Feby. 1850</dateIssued>' +
+        '<dateIssued encoding="marc">1850</dateIssued>' +
+        mods_origin_info_end_str => [1850, '1850'],
+      # nn603hs6182
+      mods_origin_info_start_str +
+        '<dateIssued>[1583]</dateIssued>' +
+        '<dateIssued encoding="marc">1583</dateIssued>' +
+        mods_origin_info_end_str => [1583, '1583'],
+      # qm011nb3364
+      mods_origin_info_start_str +
+        '<dateIssued>1606?]</dateIssued>' +
+        '<dateIssued encoding="marc">1606</dateIssued>' +
+        mods_origin_info_end_str => [1606, '1606'],
+      # ww960jk4650
+      mods_origin_info_start_str +
+        '<dateIssued>167-?]</dateIssued>' +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1670</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1680</dateIssued>' +
+        mods_origin_info_end_str => [1670, '1670 - 1680'],
+      # xf190qy2958
+      mods_origin_info_start_str +
+        '<dateIssued>1670]</dateIssued>' +
+        '<dateIssued encoding="marc">1670</dateIssued>' +
+        mods_origin_info_end_str => [1670, '1670'],
+      # nt714wx8371
+      mods_origin_info_start_str +
+        '<dateIssued>1690?]</dateIssued>' +
+        '<dateIssued encoding="marc">169u</dateIssued>' +
+        mods_origin_info_end_str => [1690, '1690s'],
+      # ct011mf9794
+      mods_origin_info_start_str +
+        '<dateIssued>17--]</dateIssued>' +
+        '<dateIssued encoding="marc">17uu</dateIssued>' +
+        mods_origin_info_end_str => [1700, '18th century'],
+      # kv453gh8092
+      mods_origin_info_start_str +
+        '<dateIssued>1809 [ca. 1810]</dateIssued>' +
+        '<dateIssued encoding="marc">1809</dateIssued>' +
+        mods_origin_info_end_str => [1809, '1809'],
+      # ms639jm9954
+      mods_origin_info_start_str +
+        '<dateIssued>183-?</dateIssued>' +
+        '<dateIssued encoding="marc">1830</dateIssued>' +
+        mods_origin_info_end_str => [1830, '1830'],
+      # mm076bz8960
+      mods_origin_info_start_str +
+        '<dateIssued>[ca. 1850?]</dateIssued>' +
+        '<dateIssued encoding="marc">185u</dateIssued>' +
+        mods_origin_info_end_str => [1850, '1850s'],
+      # kt670wv9626
+      mods_origin_info_start_str +
+        '<dateIssued>1860, [1862]</dateIssued>' +
+        '<dateIssued encoding="marc">1862</dateIssued>' +
+        mods_origin_info_end_str => [1860, '1860'],
+      # nq311rg5326
+      mods_origin_info_start_str +
+        '<dateIssued>1860?]</dateIssued>' +
+        '<dateIssued encoding="marc">186?</dateIssued>' +
+        mods_origin_info_end_str => [1860, '1860s'],
+      # cw097mp1488
+      mods_origin_info_start_str +
+        '<dateIssued>1877?</dateIssued>' +
+        '<dateIssued encoding="marc">1877</dateIssued>' +
+        mods_origin_info_end_str => [1877, '1877'],
+      # bb987ch8177
+      mods_origin_info_start_str +
+        '<dateIssued>June1st.1805</dateIssued>' +
+        '<dateIssued encoding="marc">1805</dateIssued>' +
+        mods_origin_info_end_str => [1805, '1805'],
+      # pb745bf0151
+      mods_origin_info_start_str +
+        '<dateIssued>[ca. 1730]</dateIssued>' +
+        '<dateIssued encoding="marc">1730</dateIssued>' +
+        mods_origin_info_end_str => [1730, '1730'],
+      # vs807zh4960
+      mods_origin_info_start_str +
+        '<dateIssued>[s.d.]</dateIssued>' +
+        mods_origin_info_end_str => [nil, nil],
+      # kk981sj7811
+      mods_origin_info_start_str +
+        '<dateIssued>ca. 1697]</dateIssued>' +
+        '<dateIssued encoding="marc">1697</dateIssued>' +
+        mods_origin_info_end_str => [1697, '1697'],
+      # nr266xf1214
+      mods_origin_info_start_str +
+        '<dateIssued>ca. 1740-1800]</dateIssued>' +
+        '<dateIssued encoding="marc" point="start">1740</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1800</dateIssued>' +
+        mods_origin_info_end_str => [1740, '1740 - 1800'],
+      # ds825sq5748
+      mods_origin_info_start_str +
+        '<dateIssued>s.a. [1712]</dateIssued>' +
+        '<dateIssued encoding="marc">1712</dateIssued>' +
+        mods_origin_info_end_str => [1712, '1712'],
+      # hk649cc3149
+      mods_origin_info_start_str +
+        '<dateIssued>s.a. [ca. 1780-1781]</dateIssued>' +
+        '<dateIssued encoding="marc">1780</dateIssued>' +
+        mods_origin_info_end_str => [1780, '1780'],
+      # vk991dv1917
+      mods_origin_info_start_str +
+        '<dateIssued>s.a. [zwischen 1740 und 1760]</dateIssued>' +
+        '<dateIssued encoding="marc">1740</dateIssued>' +
+        mods_origin_info_end_str => [1740, '1740'],
+      # gy889yj2171
+      mods_origin_info_start_str +
+        '<dateIssued>1758]</dateIssued>' +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1758</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">uuuu</dateIssued>' +
+        mods_origin_info_end_str => [1758, '1758']
+    },
+  # afro_am_music
+  # ai
+  # athletics intervies
+  # amica
+  # anthro
+  # antiphonary.yml
+  # baker
+  # batchelor
+  # big_idea
+  # bio_ugrad_2014
+  # bio_ugrad_2015
+  # blume
+  # carpentry
+  # cfb  ???
+  # cisac
+  # city_nature
+  # coll_barg
+  # commencement
+  # conservation
+  # ccrma
+  'dennis' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec  sg213ph2100 goes to marc 6780453
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1850</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1906</dateIssued>' +
+        mods_origin_info_end_str => [1850, '1850 - 1906'],
+      # ps072wf8793
+      mods_origin_info_start_str +
+        '<dateIssued encoding="w3cdtf">1851-07-01</dateIssued>' +
+        mods_origin_info_end_str => [1851, '1851'],
+      # cq482hj7635
+      mods_origin_info_start_str +
+        '<dateIssued>1892, Jan. 1</dateIssued>' +
+        mods_origin_info_end_str => [1892, '1892'],
+      # ps292jd8410
+      mods_origin_info_start_str +
+        '<dateIssued>December 19th, 1897</dateIssued>' +
+        mods_origin_info_end_str => [1897, '1897'],
+      # wt030np1013
+      mods_origin_info_start_str +
+        '<dateIssued>Dec. 10 & 11, 1855</dateIssued>' +
+        mods_origin_info_end_str => [1855, '1855'],
+      # pd337xr9038
+      mods_origin_info_start_str +
+        '<dateIssued>October 3, [18]91</dateIssued>' +
+        mods_origin_info_end_str => [1891, '1891'],
+      # cj765pw7168
+      mods_origin_info_start_str +
+        '<dateIssued>circa 1900</dateIssued>' +
+        mods_origin_info_end_str => [1900, '1900'],
+      # rc301fn5504
+      mods_origin_info_start_str +
+        '<dateIssued>circa 1851-1852</dateIssued>' +
+        mods_origin_info_end_str => [1851, '1851'],
+      # zz400gd3785
+      mods_origin_info_start_str +
+        '<dateIssued>copyright 1906</dateIssued>' +
+        mods_origin_info_end_str => [1906, '1906'],
+      # bh059ts1689
+      mods_origin_info_start_str +
+        '<dateIssued>early 1890s</dateIssued>' +
+        mods_origin_info_end_str => [1890, '1890s'],
+      # rm673kv3302
+      mods_origin_info_start_str +
+        '<dateIssued>published 1st July, 1851</dateIssued>' +
+        mods_origin_info_end_str => [1851, '1851'],
+      # ym037xp1637
+      mods_origin_info_start_str +
+        '<dateIssued>view of approximately 1848, published about 1865</dateIssued>' +
+        mods_origin_info_end_str => [1848, '1848']
+    },
+  # diplomatic
+  # dig_hum
+  # drosophila.yml
+  # ehrlich
+  # english_ugrad
+  # eng_physics_ugrad
+  # eng_ugrad
+  # estonian_kgb
+  'feigenbaum' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1950</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">2007</dateIssued>' +
+        mods_origin_info_end_str => [1950, '1950 - 2007'],
+      # py696hw1646, jc364jw8333
+        mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">2001-11-19</dateCreated>' +
+        mods_origin_info_end_str => [2001, '2001']
+    },
+  # fem_ugrad
+  # film_arts
+  # fitch_chavez
+  'fitch' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll recs have no originInfo data
+      # pd835hf9652 - MLK
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf" point="start" qualifier="approximate">1965</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1966</dateCreated>' +
+        mods_origin_info_end_str => [1965, '1965 - 1966'],
+      # cq153cd4213 - Panther
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">1972-03-30</dateCreated>' +
+        mods_origin_info_end_str => [1972, '1972'],
+      # rr577nj0391 - Alejo
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">2010-09</dateCreated>' +
+        mods_origin_info_end_str => [2010, '2010']
+    },
+  'fitch-mud' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec vr013gg9930  no originInfo
+      # vd865fk6168
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">1967</dateCreated>' +
+        mods_origin_info_end_str => [1967, '1967'],
+      # xr458wf5634
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">1971</dateCreated>' +
+        mods_origin_info_end_str => [1971, '1971']
+    },
+  # fitch_seeger
+  # flipside
+  # folding
+  # fracture
+  # franklin
+  # frantz
+  'fugitive_us_agencies' =>  # WARC files
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec mk656nf8485  has no dates
+      # rc607cp0203
+      mods_origin_info_start_str +
+        '<dateCaptured encoding="iso8601" point="start" keyDate="yes">20090511065738</dateCaptured>' +
+        '<dateCaptured encoding="edtf" point="end">open</dateCaptured>' +
+        mods_origin_info_end_str => [2009, '2009'],
+      # gb089bd2251
+      mods_origin_info_start_str +
+        '<dateCaptured encoding="iso8601" point="start" keyDate="yes">20121129060351</dateCaptured>' +
+        '<dateCaptured encoding="edtf" point="end">open</dateCaptured>' +
+        mods_origin_info_end_str => [2012, '2012']
+    },
+  # fuller
+  'fuller' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec rh056sr3313
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable" keyDate="yes">1920</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1983</dateIssued>' +
+        mods_origin_info_end_str => [1920, '1920 - 1983'],
+      # fz116cn2445
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">1977</dateCreated>' +
+        mods_origin_info_end_str => [1977, '1977']
+    },
+  # future_sp
+  # geo
+  # gimon
+  # gould
+  'gould' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec sp673gr4168 no originInfo
+      # cm311th5760
+      mods_origin_info_start_str +
+        '<dateIssued>1599-1601</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes" point="start">1599</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1601</dateIssued>' +
+        mods_origin_info_end_str => [1599, '1599 - 1601'],
+      # mt060jf5269
+      mods_origin_info_start_str +
+        "<dateIssued>1616: Con licenza de'svperiori</dateIssued>" +
+        '<dateIssued encoding="marc" keyDate="yes">1616</dateIssued>' +
+        mods_origin_info_end_str => [1616, '1616'],
+      # nq614fg2641
+      mods_origin_info_start_str +
+        '<dateIssued>1689 [i.e. 1688-89]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1689</dateIssued>' +
+        mods_origin_info_end_str => [1689, '1689'],
+      # vq462ct4039
+      mods_origin_info_start_str +
+        '<dateIssued>1717-1720</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1717</dateIssued>' +
+        mods_origin_info_end_str => [1717, '1717'],
+      # nh718gy4718
+      mods_origin_info_start_str +
+        '<dateIssued>1743-53</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes" point="start">1743</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1753</dateIssued>' +
+        mods_origin_info_end_str => [1743, '1743 - 1753'],
+      # vr992zn5309
+      mods_origin_info_start_str +
+        '<dateIssued>MDCCLII. [1752-</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes" point="start">1752</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1769</dateIssued>' +
+        mods_origin_info_end_str => [1752, '1752 - 1769'],
+      # ms437pv1661
+      mods_origin_info_start_str +
+        '<dateIssued>1752 [i.e. 1753]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1752</dateIssued>' +
+        mods_origin_info_end_str => [1752, '1752'],
+      # hn969cv3410
+      mods_origin_info_start_str +
+        '<dateIssued>1772]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1772</dateIssued>' +
+        mods_origin_info_end_str => [1772, '1772'],
+      # nh857kn6175
+      mods_origin_info_start_str +
+        '<dateIssued>18--]</dateIssued>' +
+        mods_origin_info_end_str => [1800, '19th century'],
+      # fz691jq4431
+      mods_origin_info_start_str +
+        '<dateIssued>1846-</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes" point="start">1846</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">9999</dateIssued>' +
+        mods_origin_info_end_str => [1846, '1846'],
+      # zp382js2355
+      mods_origin_info_start_str +
+        '<dateIssued>[184-]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">184u</dateIssued>' +
+        mods_origin_info_end_str => [1840, '1840s'],
+      # qg377px6180
+      mods_origin_info_start_str +
+        '<dateIssued>1868, c1857</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1868</dateIssued>' +
+        '<copyrightDate encoding="marc">1857</copyrightDate>' +
+        mods_origin_info_end_str => [1868, '1868'],
+      # df994hc9746
+      mods_origin_info_start_str +
+        '<dateIssued>[18--?]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">18uu</dateIssued>' +
+        mods_origin_info_end_str => [1800, '19th century'],
+      # wt924zz1420
+      mods_origin_info_start_str +
+        '<dateIssued>c1999</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1999</dateIssued>' +
+        mods_origin_info_end_str => [1999, '1999'],
+      # pk964hd1543
+      mods_origin_info_start_str +
+        '<dateIssued>1920</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1900</dateIssued>' +
+        mods_origin_info_end_str => [1900, '1900'],
+      # nq054by6214
+      mods_origin_info_start_str +
+        '<dateIssued>200-?]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">200u</dateIssued>' +
+        mods_origin_info_end_str => [2000, '2000s'],
+      # sf621tq9900
+      mods_origin_info_start_str +
+        '<dateIssued>an X, 1802</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1802</dateIssued>' +
+        mods_origin_info_end_str => [1802, '1802'],
+      # sn157dn6711
+      mods_origin_info_start_str +
+        '<dateIssued>c1964</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1964</dateIssued>' +
+        mods_origin_info_end_str => [1964, '1964'],
+      # yp117pm9679
+      mods_origin_info_start_str +
+        '<dateIssued>[etc</dateIssued>' +
+        '<dateIssued>1840]</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1840</dateIssued>' +
+        mods_origin_info_end_str => [1840, '1840'],
+      # qt751sy2894
+      mods_origin_info_start_str +
+        '<dateIssued>MDCLXXXVII</dateIssued>' +
+        '<dateIssued encoding="marc" keyDate="yes">1687</dateIssued>' +
+        mods_origin_info_end_str => [1687, '1687']
+    },
+  # gse_comp_ed_masters
+  # gse_oa
+  # gse_ugrad
+  # hellman
+  'homebrew' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec ht445nv3709  no originInfo
+      # xt205qz2409
+      mods_origin_info_start_str +
+        '<dateIssued encoding="w3cdtf" keyDate="yes">1978-01</dateIssued>' +
+        mods_origin_info_end_str => [1978, '1978']
+    },
+  # hopkins
+  # hopkins_thesis
+  # human_bio_lectures
+  # hummel
+  # image_proc
+  # image_video_multimedia
+  # jane_stanford
+  # jordan
+  # kant
+  # kemi
+  'kitai' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec rw431mw4432
+      mods_origin_info_start_str +
+        '<dateIssued>[1968?-</dateIssued>' +
+        '<dateIssued encoding="marc" point="start" keyDate="yes">1968</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">9999</dateIssued>' +
+        mods_origin_info_end_str => [1968, '1968'],
+      # tw488bz3281
+      mods_origin_info_start_str +
+        '<dateIssued>[1968?-</dateIssued>' +
+        '<dateIssued encoding="marc" point="start" keyDate="yes">1968</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">9999</dateIssued>' +
+        mods_origin_info_end_str => [1968, '1968']
+    },
+  # kolb has no originInfo elements
+  'labor' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec wf220dz0066  merges with 421708
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1948</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">9999</dateIssued>' +
+        mods_origin_info_end_str => [1948, '1948'],
+      # vh590xb4582
+      mods_origin_info_start_str +
+        '<dateIssued encoding="w3cdtf" keyDate="yes" qualifier="approximate" point="start">1948</dateIssued>' +
+        '<dateIssued encoding="w3cdtf" qualifier="approximate" point="end">1951</dateIssued>' +
+        mods_origin_info_end_str => [1948, '1948 - 1951']
+    },
+  # lapp_practices
+  # leland_stanford
+  # lgbt
+  # lobell
+  # masters
+  # matter
+  # maxfield
+  'mccarthy' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec kd453rz2514
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1951</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">2008</dateIssued>' +
+        mods_origin_info_end_str => [1951, '1951 - 2008'],
+      # kr251bd1719
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">Undated</dateCreated>' +
+        mods_origin_info_end_str => [nil, nil],
+      # kt770bs1887
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">1978-06</dateCreated>' +
+        mods_origin_info_end_str => [1978, '1978'],
+      # zw479my8350
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">2010-12-09</dateCreated>' +
+        mods_origin_info_end_str => [2010, '2010']
+    },
+  'mclaughlin_ca_island' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec zb871zd0767 no dates
+      # tt437zq0720
+      mods_origin_info_start_str +
+        '<dateIssued>1640-1665?]</dateIssued>' +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1640</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1665</dateIssued>' +
+        mods_origin_info_end_str => [1640, '1640 - 1655'],
+      # rk097dw1744
+      mods_origin_info_start_str +
+        '<dateIssued>1640]</dateIssued>' +
+        '<dateIssued encoding="marc">1640</dateIssued>' +
+        mods_origin_info_end_str => [1640, '1640'],
+      # mk758ps0914
+      mods_origin_info_start_str +
+        '<dateIssued>1598 or 1599]</dateIssued>' +
+        '<dateIssued encoding="marc">1599</dateIssued>' +
+        mods_origin_info_end_str => [1598, '1598'],
+      # nc111sz1016
+      mods_origin_info_start_str +
+        '<dateIssued>1643?]</dateIssued>' +
+        '<dateIssued encoding="marc">1643</dateIssued>' +
+        mods_origin_info_end_str => [1643, '1643'],
+      # nh040md8464
+      mods_origin_info_start_str +
+        '<dateIssued>1643]</dateIssued>' +
+        '<dateIssued encoding="marc">1643</dateIssued>' +
+        mods_origin_info_end_str => [1643, '1643'],
+      # kn933tp3421
+      mods_origin_info_start_str +
+        '<dateIssued>168-?]</dateIssued>' +
+        '<dateIssued encoding="marc">168u</dateIssued>' +
+        mods_origin_info_end_str => [1680, '1680s'],
+      # cm303hd3051
+      mods_origin_info_start_str +
+        '<dateIssued>17--?]</dateIssued>' +
+        '<dateIssued encoding="marc">17uu</dateIssued>' +
+        mods_origin_info_end_str => [1700, '18th century'],
+      # qg633rp87199h
+      mods_origin_info_start_str +
+        '<dateIssued>17--]</dateIssued>' +
+        '<dateIssued encoding="marc">17uu</dateIssued>' +
+        mods_origin_info_end_str => [1700, '18th century'],
+      # cg009ks6415
+      mods_origin_info_start_str +
+        '<dateIssued>ca.170-?]</dateIssued>' +
+        '<dateIssued encoding="marc">170u</dateIssued>' +
+        mods_origin_info_end_str => [1700, '1700s'],
+      # cy085vp3914
+      mods_origin_info_start_str +
+        '<dateIssued>[171-?]</dateIssued>' +
+        '<dateIssued encoding="marc">171u</dateIssued>' +
+        mods_origin_info_end_str => [1710, '1710s'],
+      # nn822ff0715
+      mods_origin_info_start_str +
+        '<dateIssued>Anno 1622</dateIssued>' +
+        '<dateIssued encoding="marc">1622</dateIssued>' +
+        mods_origin_info_end_str => [1622, '1622'],
+      # mn182sb2675
+      mods_origin_info_start_str +
+        '<dateIssued>[17--]</dateIssued>' +
+        '<dateIssued encoding="marc">17uu</dateIssued>' +
+        mods_origin_info_end_str => [1700, '18th century'],
+      # ws465kb7898
+      mods_origin_info_start_str +
+        '<dateIssued>[17--?]</dateIssued>' +
+        '<dateIssued encoding="marc">17uu</dateIssued>' +
+        mods_origin_info_end_str => [1700, '18th century'],
+      # sm817db3005
+      mods_origin_info_start_str +
+        '<dateIssued>[1764-1782]</dateIssued>' +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1764</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1782</dateIssued>s' +
+        mods_origin_info_end_str => [1764, '1764 - 1782'],
+      # dt360jc3286
+      mods_origin_info_start_str +
+        '<dateIssued>[ca. 1700]</dateIssued>' +
+        '<dateIssued encoding="marc">1700</dateIssued>' +
+        mods_origin_info_end_str => [1700, '1700'],
+      # qc461vk9235
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">1666</dateCreated>' +
+        '<dateCreated keyDate="no" qualifier="inferred">1666</dateCreated>' +
+        mods_origin_info_end_str => [1666, '1666'],
+      # pt603pv6417
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes">1698/1715</dateCreated>' +
+        mods_origin_info_end_str => [1698, '1698'],
+      # cr498zz3120
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" qualifier="inferred">1700?</dateCreated>' +
+        mods_origin_info_end_str => [1700, '1700'],
+      # px053ft5911
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">1732</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="no" qualifier="questionable">1732</dateCreated>' +
+        mods_origin_info_end_str => [1732, '1732'],
+      # xb526qv4524
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="no" point="end" qualifier="approximate">1939</dateCreated>' +
+        '<dateCreated keyDate="yes" point="" qualifier="approximate">1930</dateCreated>' +
+        mods_origin_info_end_str => [1930, '1930']
+    },
+  # mclaughlin_malta
+  # medieval / mss
+  'mss' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec dt056jp2574  (actually merges with marc 4082840)
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start" keyDate="yes">0850</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1499</dateIssued>' +
+        mods_origin_info_end_str => [850, '850 A.D. - 1499'],
+      # coll rec  bd001pp3337
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" keyDate="yes" point="start">1000</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1599</dateIssued>' +
+        mods_origin_info_end_str => [1000, '1000 - 1599'],
+      # coll rec fn508pj9953
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1400</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1600</dateIssued>' +
+        mods_origin_info_end_str => [1400, '1400 - 1600'],
+      # coll rec nd057tw6238
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start" keyDate="yes">1404</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1781</dateIssued>' +
+        mods_origin_info_end_str => [1404, '1404 - 1781'],
+      # coll rec pn981gz2244
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1310</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1500</dateIssued>' +
+        mods_origin_info_end_str => [1310, '1310 - 1500'],
+      # coll rec zv022sd1415
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" keyDate="yes" point="start" qualifier="questionable">1100</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1499</dateIssued>' +
+        mods_origin_info_end_str => [1100, '1100 - 1499'],
+      # hf970tz9706
+      mods_origin_info_start_str +
+        '<dateCreated point="start" qualifier="approximate" keyDate="yes">850</dateCreated>' +
+        '<dateCreated point="end" qualifier="approximate">1499</dateCreated>' +
+        mods_origin_info_end_str => [850, '850 A.D. - 1499'],
+      # sc582cv9633
+      mods_origin_info_start_str +
+        '<dateCreated keydate="yes">1314</dateCreated>' +
+        mods_origin_info_end_str => [1314, '1314'],
+      # yc365tw0116
+      mods_origin_info_start_str +
+        '<dateCreated point="start" qualifier="approximate" keyDate="yes">1404</dateCreated>' +
+        '<dateCreated point="end" qualifier="approximate">1781</dateCreated>' +
+        mods_origin_info_end_str => [1404, '1404 - 1781'],
+      # mf790cw8283
+      mods_origin_info_start_str +
+        '<dateCreated keydate="yes">August 18, 1552</dateCreated>' +
+        mods_origin_info_end_str => [1552, '1552']
+    },
+  # menuez
+  'me310' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec kq629sd5182 no date
+      # sd594yd8504
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">2013-06-24</dateCreated>' +
+        mods_origin_info_end_str => [2013, '2013'],
+      # sw321tg6624
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf">2013-06</dateCreated>' +
+        mods_origin_info_end_str => [2013, '2013']
+    },
+  # mkultra
+  # mlk
+  # mlm ?
+  # mpeg
+  # mullin-palmer
+  # nanoscale
+  'norwich' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec qb438pg7646
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1486</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1865</dateIssued>' +
+        mods_origin_info_end_str => [1486, '1486 - 1865'],
+      # zv656kg5843
+      mods_origin_info_start_str +
+        '<dateIssued qualifier="questionable" point="start" keyDate="yes">1486</dateIssued>' +
+        '<dateIssued qualifier="questionable" point="end">1865</dateIssued>' +
+        mods_origin_info_end_str => [1486, '1486 - 1865'],
+      # qx376cz2677
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier="inferred">1814</dateCreated>' +
+        mods_origin_info_end_str => [1814, '1814'],
+      # fw226jy0133
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier="inferred">1486</dateCreated>' +
+        mods_origin_info_end_str => [1486, '1486'],
+      # xp797gj2926
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier="approximate" point="start">1646</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="no" qualifier="approximate" point="end">1647</dateCreated>' +
+        mods_origin_info_end_str => [1646, '1646 - 1647'],
+      # by909qy2837
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier="">1795</dateCreated>' +
+        mods_origin_info_end_str => [1795, '1795']
+    },
+  'nowinsky' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec sk882gx0113  but merges to marc 9685083
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start">1981</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end">1982</dateCreated>' +
+        mods_origin_info_end_str => [1981, '1981 - 1982'],
+      # st181pw3134
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start">1981</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end">1982</dateCreated>' +
+        mods_origin_info_end_str => [1981, '1981 - 1982']
+    },
+  # paleo
+  'papyri' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec jr022nf7673 has no dates
+      # jx555jt0710
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">199 B.C.</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="end" qualifier="approximate">100 B.C.</dateCreated>' +
+        mods_origin_info_end_str => [-199, '199 B.C. - 100 B.C.'],
+      # ww728rz0477
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">211 B.C.</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="end" qualifier="approximate">150 B.C.</dateCreated>' +
+        mods_origin_info_end_str => [-211, '211 B.C. - 150 B.C.']
+    },
+  # pcc
+  # peace
+  # peninsula_times ?
+  # peoples_computer?
+  # physics_ugrad
+  # pippin
+  # pleistocene
+  'posada' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec fm601nw4733 merges with 4561410
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start" qualifier="questionable">1875</dateIssued>' +
+        '<dateIssued encoding="marc" point="end" qualifier="questionable">1913</dateIssued>' +
+        mods_origin_info_end_str => [1875, '1875 - 1913'],
+      # wb612pd9842
+      mods_origin_info_start_str +
+        '<dateCreated keyDate="yes" encoding="w3cdtf" point="start" qualifier="approximate">1852</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1925</dateCreated>' +
+        mods_origin_info_end_str => [1852, '1852 - 1925']
+    },
+  # posttranslational
+  # project_south
+  # reaction_kinetics?
+  # reliability
+  # renaissance
+  'xxx' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec sr605np6062 no originInfo
+      # mj187xt5183
+      mods_origin_info_start_str +
+        '<dateIssued>A1566</dateIssued>' +
+        '<dateIssued encoding="marc">1566</dateIssued>' +
+        mods_origin_info_end_str => [1566, '1566'],
+      # sy295vm4054
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1613</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1622</dateIssued>' +
+        '<dateIssued>1613</dateIssued>' +
+        '<dateIssued/>' +
+        mods_origin_info_end_str => [1613, '1613 - 1622']
+    },
+  # renuwit
+  'research-data' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec md919gh6774 no originInfo
+      # qt411pj4511
+      mods_origin_info_start_str +
+        '<dateCreated point="start" keyDate="yes" encoding="w3cdtf">2009-05-10</dateCreated>' +
+        '<dateCreated point="end" encoding="w3cdtf">2014-10-30</dateCreated>' +
+        mods_origin_info_end_str => [2009, '2009 - 2014'],
+      # zp707tw3135
+      mods_origin_info_start_str +
+        '<dateCreated qualifier="approximate" keyDate="yes" encoding="w3cdtf">2008</dateCreated>' +
+        mods_origin_info_end_str => [2008, '2008'],
+      # pw096jw7895
+      mods_origin_info_start_str +
+        '<dateCreated point="start" qualifier="approximate" keyDate="yes" encoding="w3cdtf">2014-03</dateCreated>' +
+        '<dateCreated point="end" qualifier="approximate" encoding="w3cdtf">2015-06</dateCreated>' +
+        mods_origin_info_end_str => [2014, '2014 - 2015']
+    },
+  # reservoir ?
+  'roman coins' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec dq017bh9237 no dates
+      # hs628wg6771
+      mods_origin_info_start_str +
+        '<dateCreated encoding="edtf" point="start" keyDate="yes">-18</dateCreated>' +
+        '<dateCreated encoding="edtf" point="end">-17</dateCreated>' +
+        mods_origin_info_end_str => [-18, '18 B.C. - 17 B.C.'],
+      # bb408km1389
+      mods_origin_info_start_str +
+        '<dateCreated encoding="edtf" point="start" keyDate="yes">-1</dateCreated>' +
+        '<dateCreated encoding="edtf" point="end">11</dateCreated>' +
+        mods_origin_info_end_str => [-1, '1 B.C. - 11 A.D.'],
+      # cs470ng8064
+      mods_origin_info_start_str +
+        '<dateCreated encoding="edtf" point="start" keyDate="yes">-1</dateCreated>' +
+        '<dateCreated encoding="edtf" point="end">0</dateCreated>' +
+        mods_origin_info_end_str => [-1, '1 B.C. - 0 A.D.'],
+      # vh834jh5059
+      mods_origin_info_start_str +
+        '<dateCreated encoding="edtf" point="start" keyDate="yes">13</dateCreated>' +
+        '<dateCreated encoding="edtf" point="end">14</dateCreated>' +
+        mods_origin_info_end_str => [13, '13 A.D. - 14 A.D.'],
+      # sk424bh9379
+      mods_origin_info_start_str +
+        '<dateCreated encoding="edtf" point="start" keyDate="yes">34</dateCreated>' +
+        '<dateCreated encoding="edtf" point="end">35</dateCreated>' +
+        mods_origin_info_end_str => [34, '34 A.D. - 35 A.D.']
+    },
+  # rigler
+  # rumsey
+  'rumsey' =>
+  { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+    # coll rec xh235dd9059 no originInfo
+    # fy259fg4220
+    mods_origin_info_start_str +
+      '<dateIssued>1855.</dateIssued>' +
+      mods_origin_info_end_str => [1855, '1855'],
+    # hp058zk7170
+    mods_origin_info_start_str +
+      '<dateCreated encoding="marc">1861</dateCreated>' +
+      '<dateIssued>1861.</dateIssued>' +
+      mods_origin_info_end_str => [1861, '1861'],
+  },
+  # rock?
+  # scrf
+  # shale
+  'shpc' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec kx532cb7981
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">1887</dateIssued>' +
+        '<dateIssued encoding="marc" point="end">1996</dateIssued>' +
+        mods_origin_info_end_str => [1887, '1887 - 1996'],
+      # cr293hs9054
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier="">0000-00-00</dateCreated>' +
+        mods_origin_info_end_str => [nil, nil],
+      # dk829wf6922
+      mods_origin_info_start_str +
+        '<dateOther encoding="w3cdtf" keyDate="no" qualifier="">1958-07-00</dateOther>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier=" ">1869-00-00</dateCreated>' +
+        mods_origin_info_end_str => [1869, '1869'],
+      # fp085hf5015
+      mods_origin_info_start_str +
+        '<dateOther encoding="w3cdtf" keyDate="no" qualifier="">1963-10-11</dateOther>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier=" ">1903-00-00</dateCreated>' +
+        mods_origin_info_end_str => [1903, '1903'],
+      # jw898zj1914
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="no" qualifier="">1903-00-00</dateCreated>' +
+        mods_origin_info_end_str => [1903, '1903'],
+      # qc093gq8747
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier=" ">1903-00-00</dateCreated>' +
+        mods_origin_info_end_str => [1903, '1903'],
+      # rb666zx7087
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier="approximate">1903-00-00</dateCreated>' +
+        mods_origin_info_end_str => [1903, '1903'],
+      # ft626rm4963
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" qualifier=" ">1972-07-00</dateCreated>' +
+        mods_origin_info_end_str => [1972, '1972'],
+      # ns466nn0465
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="no" qualifier="">1918-00-00</dateCreated>' +
+        '<dateOther encoding="w3cdtf" keyDate="no" qualifier="">1968-02-00</dateOther>' +
+        mods_origin_info_end_str => [1918, '1918']
+    },
+  # social_research_tech_reports ?
+  # sounds?
+  # spoke
+  # stafford
+  # stop_aids
+  # sul_staff
+  # tide_prediction?
+  # understanding_911?
+  # urban
+  # virtual_worlds
+  # visitations
+  # vista
+  'walters' =>
+    { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]
+      # coll rec ww121ss5000
+      mods_origin_info_start_str +
+        '<dateIssued encoding="marc" point="start">800</dateIssued>' +
+        '<dateIssued encoding="marc" point="start">1899</dateIssued>' +
+        mods_origin_info_end_str => [800, '800 A.D.'],
+      # dc882bs3541
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" point="start" qualifier="approximate" keyDate="yes">0700</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">0799</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
+        mods_origin_info_end_str => [700, '700 A.D. - 799 A.D.'],
+      # hg026ds6978
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes">0816</dateCreated>' +
+        mods_origin_info_end_str => [816, '816 A.D.'],
+      # ct437ht0445
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">0900</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">0999</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
+        mods_origin_info_end_str => [900, '900 A.D. - 999 A.D.'],
+      # ch617yk2621
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1000</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1040</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
+        mods_origin_info_end_str => [1000, '1000 - 1040'],
+      # pc969nh5331
+      mods_origin_info_start_str +
+        '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">0950</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1000</dateCreated>' +
+        '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
+        mods_origin_info_end_str => [950, '950 A.D. - 1000'],
+      # hj537kj5737
+      mods_origin_info_start_str +
+        '<dateIssued>15th century CE</dateIssued>' +
+        mods_origin_info_end_str => [1400, '15th century'],
+      # gs755tr2814
+      mods_origin_info_start_str +
+        '<dateIssued>Ca. 1580 CE</dateIssued>' +
+        mods_origin_info_end_str => [1580, '1580'],
+      # hp976mx6580
+      mods_origin_info_start_str +
+        '<dateIssued>1500 CE</dateIssued>' +
+        mods_origin_info_end_str => [1500, '1500']
+    },
+  # water
+  # wilpf?
+  # yotsuba
+}

--- a/spec/fixtures/spotlight_pub_date_data.rb
+++ b/spec/fixtures/spotlight_pub_date_data.rb
@@ -156,7 +156,7 @@ SPOTLIGHT_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateIssued encoding="marc" point="start" keyDate="yes">0850</dateIssued>' +
         '<dateIssued encoding="marc" point="end">1499</dateIssued>' +
-        mods_origin_info_end_str => ['0850', '850'],
+        mods_origin_info_end_str => ['0850', '850 A.D.'],
       # nc881qb8504
       mods_origin_info_start_str +
         '<dateCreated point="start" qualifier="approximate" keyDate="yes">1000</dateCreated>' +

--- a/spec/origin_info_spec.rb
+++ b/spec/origin_info_spec.rb
@@ -79,8 +79,8 @@ describe "computations from /originInfo field" do
     end
   end
 
-  context '#pub_date_facet_single_value' do
-    it_behaves_like "single pub date value", :pub_date_facet_single_value, 1
+  context '#pub_year_display_str' do
+    it_behaves_like "single pub date value", :pub_year_display_str, 1
   end
 
   context '#pub_year_sort_str' do
@@ -226,14 +226,14 @@ describe "computations from /originInfo field" do
     end
   end
 
-  context '#year_facet_str' do
-    it_behaves_like "pub date best single value", :year_facet_str
+  context '#year_display_str' do
+    it_behaves_like "pub date best single value", :year_display_str
     it 'uses facet value, not sorting value' do
       mods_str = mods_origin_info_start_str +
         '<dateCreated keyDate="yes">180 B.C.</dateCreated>' +
         mods_origin_info_end_str
       smods_rec.from_str(mods_str)
-      expect(smods_rec.year_facet_str(smods_rec.date_created_elements)).to eq '180 B.C.'
+      expect(smods_rec.year_display_str(smods_rec.date_created_elements)).to eq '180 B.C.'
     end
   end
 

--- a/spec/sw_publication_spec.rb
+++ b/spec/sw_publication_spec.rb
@@ -1,0 +1,29 @@
+describe "SearchWorks Publication methods" do
+
+  let(:smods_rec) { Stanford::Mods::Record.new }
+  RSpec.shared_examples "pub year" do |method_sym, exp_val_position|
+    context 'searchworks actual data' do
+      require 'fixtures/searchworks_pub_date_data'
+      SEARCHWORKS_PUB_DATE_DATA.each_pair.each do |coll_name, coll_data|
+        coll_data.each_pair do |mods_str, exp_vals|
+          expected = exp_vals[exp_val_position]
+          # TODO:  pub_year_display_str doesn't cope with date ranges yet
+          expected = expected.split(' - ')[0] if method_sym == :pub_year_display_str && expected
+          it "#{expected} for rec in #{coll_name}" do
+            smods_rec.from_str(mods_str)
+            expect(smods_rec.send(method_sym)).to eq expected
+          end
+        end
+      end
+    end
+  end
+
+  context '#pub_year_int' do
+    it_behaves_like "pub year", :pub_year_int, 0
+  end
+
+  context '#pub_year_display_str' do
+    it_behaves_like "pub year", :pub_year_display_str, 1
+  end
+
+end


### PR DESCRIPTION
#pub_year_display_str  replaces #facet_string_from_date_str (which was new and unused)
- adds B.C. to dates before year 0 (fixes #56)
- adds A.D. to dates (fixes #56)
- nice string for decades (1950s for 195u) (connects to #53)
- nice string for centuries (18th century for 17uu)  (connects to #53)

does NOT handle date ranges -- takes first year from range.

connects to sul-dlss/sw-indexer-service#43 (search results piece of index BCE dates for coin collection)
connects to sul-dlss/solrmarc-sw#111 (BCE dates for coin collection)
connects to sul-dlss/SearchWorks#1140 (fix mods date display in search results)