### PR TITLE
rename location method to avoid clash with super class definition in mods gem

### DIFF
--- a/config/mappings_hash.rb
+++ b/config/mappings_hash.rb
@@ -30,7 +30,7 @@ name_to_xpath = {
   'physical_description_form'       => '//physicalDescription/form/text()', # .to_s
   'physical_description_media_type' => '//physicalDescription/internetMediaType/text()', # .to_s
 
-# location
+# physical_location
   'physical_location' => '//location/physicalLocation/text()', # .to_s
   'location_url'      => '//location/url/text()', # .to_s
 

--- a/lib/stanford-mods/physical_location.rb
+++ b/lib/stanford-mods/physical_location.rb
@@ -47,12 +47,13 @@ module Stanford
         folder_num.first
       end
 
-      # return entire contents of physicalLocation (note: single valued)
+      # return entire contents of physicalLocation as a string (note: single valued)
       #   but only if it has series, accession, box or folder data
       #   data in location/physicalLocation or in relatedItem/location/physicalLocation
       #   so use _location to get the data from either one of them
       # TODO:  should it be hierarchical series/box/folder?
-      def location
+      # NOTE: there is a "physicalLocation" and a "location" method defined in the mods gem, so we cannot use these names to avoid conflicts
+      def physical_location_str
         #   _location.physicalLocation should find top level and relatedItem
         loc = @mods_ng_xml._location.physicalLocation.map do |node|
           node.text if node.text.match(/.*(Series)|(Accession)|(Folder)|(Box).*/i)

--- a/lib/stanford-mods/version.rb
+++ b/lib/stanford-mods/version.rb
@@ -1,6 +1,6 @@
 module Stanford
   module Mods
     # this is the Ruby Gem version
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/spec/physical_location_spec.rb
+++ b/spec/physical_location_spec.rb
@@ -179,19 +179,19 @@ describe "Physical Location for series, box, folder" do
         context 'in /location/physicalLocation' do
           it "has the expected location '#{expected}'" do
             @smods_rec.from_str(mods_loc_phys_loc)
-            expect(@smods_rec.location).to eq expected
+            expect(@smods_rec.physical_location_str).to eq expected
           end
         end
         context 'in /relatedItem/location/physicalLocation' do
           it "has the expected location '#{expected}'" do
             @smods_rec.from_str(mods_rel_item_loc_phys_loc)
-            expect(@smods_rec.location).to eq expected
+            expect(@smods_rec.physical_location_str).to eq expected
           end
         end
         context 'with multiple physicalLocation elements' do
           it "has the expected location '#{expected}'" do
             @smods_rec.from_str(mods_loc_multiple_phys_loc)
-            expect(@smods_rec.location).to eq expected
+            expect(@smods_rec.physical_location_str).to eq expected
           end
         end
       end # for example


### PR DESCRIPTION
fixes #71 

version bump to 2.1, while technically this should be 3.0, 2.0 was just released this morning, so i am piggybacking on that major version change with this non-backwards compatible change

once merged, i will cut the new gem, deploy and then update spotlight-dor-services

@lmcglohon @ndushay 
