### PR TITLE
Various cops and cleanups, leftover refactors

### DIFF
--- a/lib/stanford-mods/geo_spatial.rb
+++ b/lib/stanford-mods/geo_spatial.rb
@@ -18,14 +18,15 @@ module Stanford
       #  <gml:upperCorner>-122.149475 37.4435369</gml:upperCorner>
       def geo_extensions_as_envelope
         mods_ng_xml.extension
-                    .xpath('//rdf:RDF/rdf:Description/gml:boundedBy/gml:Envelope',
-                      'gml' => GMLNS,
-                      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
-                    ).map do |v|
-                      uppers = v.xpath('gml:upperCorner', 'gml' => GMLNS).text.split
-                      lowers = v.xpath('gml:lowerCorner', 'gml' => GMLNS).text.split
-                      "ENVELOPE(#{lowers[0]}, #{uppers[0]}, #{uppers[1]}, #{lowers[1]})"
-                    end
+                   .xpath(
+                     '//rdf:RDF/rdf:Description/gml:boundedBy/gml:Envelope',
+                     'gml' => GMLNS,
+                     'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+                   ).map do |v|
+                     uppers = v.xpath('gml:upperCorner', 'gml' => GMLNS).text.split
+                     lowers = v.xpath('gml:lowerCorner', 'gml' => GMLNS).text.split
+                     "ENVELOPE(#{lowers[0]}, #{uppers[0]}, #{uppers[1]}, #{lowers[1]})"
+                   end
       rescue RuntimeError => e
         logger.warn "failure parsing <extension> element: #{e.message}"
         []
@@ -47,6 +48,6 @@ module Stanford
       end
 
       alias point_bbox coordinates_as_bbox
-    end # class Record
-  end # Module Mods
-end # Module Stanford
+    end
+  end
+end


### PR DESCRIPTION
- When you are going to call .first on the result of .map/.each, don't
  waste time continuing to loop after the first successful hit
- Guard clauses, people!
- Factor out the lines that are in both halves of an if/else conditional
- Other rubocop-directed amendments
- YARD docs formalized where possible
- argument version of .map/.select/.reject, e.g. `.map(&:name)`
