### PR TITLE
Deal with blank titlenodes

### DIFF
--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -127,12 +127,16 @@ module Stanford
 
       # @return [String] value for title_245a_search field
       def sw_short_title
-        short_titles ? short_titles.first : nil
+        short_titles ? short_titles.compact.reject(&:empty?).first : nil
       end
 
+      # @return [Nokogiri::XML::NodeSet] title_info nodes, rejecting ones that just have blank text values
+      def outer_nodes
+        mods_ng_xml.title_info.reject {|node| node.text.strip.empty?}
+      end
+      
       # @return [String] value for title_245_search, title_full_display
       def sw_full_title
-        outer_nodes = mods_ng_xml.title_info
         outer_node = outer_nodes ? outer_nodes.first : nil
         return nil unless outer_node
         nonSort = outer_node.nonSort.text.strip.empty? ? nil : outer_node.nonSort.text.strip
@@ -157,6 +161,7 @@ module Stanford
         parts.sub!(/\.$/, '') if parts
 
         result = parts ? preParts + ". " + parts : preParts
+        return nil unless result
         result += "." unless result =~ /[[:punct:]]$/
         result.strip!
         result = nil if result.empty?

--- a/lib/stanford-mods/searchworks.rb
+++ b/lib/stanford-mods/searchworks.rb
@@ -37,9 +37,8 @@ module Stanford
                     result << SEARCHWORKS_LANGUAGES[v.strip]
                   end
                 end
-              rescue
-                # TODO:  this should be written to a logger
-                p "Couldn't find english name for #{ct.text}"
+              rescue RuntimeError
+                logger.warn "Couldn't find english name for #{ct.text}"
               end
             else
               vals = ct.text.split(/[,|\ ]/).reject { |x| x.strip.empty? }

--- a/spec/searchworks_spec.rb
+++ b/spec/searchworks_spec.rb
@@ -14,6 +14,28 @@ describe "Searchworks mixin for Stanford::Mods::Record" do
       expect(langs).to include("Persian", "Arabic", "Dutch")
       expect(langs).not_to include("Dutch; Flemish")
     end
+    it "should deal with a missing authority by ignoring it and still looking up the language code" do
+      m = "<mods #{@ns_decl}> <language><languageTerm type='code'>eng</languageTerm></language></mods>"
+      @smods_rec.from_str m
+      langs = @smods_rec.sw_language_facet
+      expect(langs.size).to eq(1)
+      expect(langs).to eq ["English"]
+      expect(langs).not_to include("eng")
+    end
+    it "should deal with an unknown language code by ignoring it and returning nil" do
+      m = "<mods #{@ns_decl}> <language><languageTerm type='code'>bbc</languageTerm></language></mods>"
+      @smods_rec.from_str m
+      langs = @smods_rec.sw_language_facet
+      expect(langs.size).to be 1
+      expect(langs).to eq [nil]
+    end
+    it "should deal with an unspecified language code by ignoring it and returning nothing" do
+      m = "<mods #{@ns_decl}> <language><languageTerm>bbc</languageTerm></language></mods>"
+      @smods_rec.from_str m
+      langs = @smods_rec.sw_language_facet
+      expect(langs.size).to be 0
+      expect(langs).to eq []
+    end    
     it "should not have duplicates" do
       m = "<mods #{@ns_decl}><language><languageTerm type='code' authority='iso639-2b'>eng</languageTerm><languageTerm type='text'>English</languageTerm></language></mods>"
       @smods_rec.from_str m

--- a/spec/searchworks_title_spec.rb
+++ b/spec/searchworks_title_spec.rb
@@ -7,7 +7,7 @@ describe 'title fields (searchworks.rb)' do
     @smods_rec.from_str m
   end
 
-  context 'short title (for title_245a_search, title_245a_display) ' do
+  context 'short title (for title_245a_search, title_245a_display)' do
     it 'should call :short_titles' do
       expect(@smods_rec).to receive(:short_titles) # in Mods gem
       @smods_rec.sw_short_title
@@ -17,6 +17,16 @@ describe 'title fields (searchworks.rb)' do
     end
   end
 
+  context 'blank title node' do
+    it 'should deal with a second blank titleInfo node' do
+      m = "<mods #{@ns_decl}><titleInfo> </titleInfo><otherStuff>goes here</otherStuff><titleInfo><title>Jerk</title><subTitle>A Tale of Tourettes</subTitle><nonSort>The</nonSort></titleInfo></mods>"
+      smods_rec_blank_node = Stanford::Mods::Record.new
+      smods_rec_blank_node.from_str m
+      expect(smods_rec_blank_node.sw_short_title).to eq 'The Jerk'
+      expect(smods_rec_blank_node.sw_full_title).to eq 'The Jerk : A Tale of Tourettes.'
+    end
+  end
+  
   context 'full title (for title_245_search, title_full_display)' do
     it 'should be a String' do
       expect(@smods_rec.sw_full_title).to eq 'The Jerk : A Tale of Tourettes.'


### PR DESCRIPTION
1. deal with the case of an object that has an additional blank <titleInfo> node...the previous behavior threw a 500 exception, the new behavior simply discards totally blank nodes when performing searchworks title logic

2. DRYing out of common code for title parsing into methods

3. write some tests to confirm how language parsing is dealt with

fixes sul-dlss/discovery-dispatcher#122