### PR TITLE
Allow any case for the marcrelator term when determining main author.

### DIFF
--- a/lib/stanford-mods/name.rb
+++ b/lib/stanford-mods/name.rb
@@ -17,7 +17,7 @@ module Stanford
           first_wo_role ||= n if n.role.empty?
           n.role.each { |r|
             if r.authority.include?('marcrelator') &&
-                  (r.value.include?('Creator') || r.value.include?('Author'))
+                 r.value.any? { |v| v.match(/creator/i) || v.match?(/author/i) }
               result ||= n.display_value_w_date
             end
           }

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -11,7 +11,7 @@ describe "name/author concepts" do
                           </name>" }
     let(:plain_creator_text) { "<name>
                               <namePart>plain_creator_text</namePart>
-                              <role><roleTerm type='text' authority='marcrelator'>Creator</roleTerm></role>
+                              <role><roleTerm type='text' authority='marcrelator'>creator</roleTerm></role>
                           </name>" }
     let(:plain_creator_non_mr) { "<name>
                               <namePart>plain_creator_non_mr</namePart>
@@ -23,7 +23,7 @@ describe "name/author concepts" do
                           </name>" }
     let(:plain_author_text) { "<name>
                               <namePart>plain_author_text</namePart>
-                              <role><roleTerm type='text' authority='marcrelator'>Author</roleTerm></role>
+                              <role><roleTerm type='text' authority='marcrelator'>author</roleTerm></role>
                           </name>" }
     let(:plain_author_non_mr) { "<name>
                               <namePart>plain_author_non_mr</namePart>


### PR DESCRIPTION
Currently, some records (e.g. sp915nb0457) have marcrelator terms but they're not capitalized as expected.  We will follow up with folks on the metadata side to see if anything could/should be addressed to correct this data and/or the processes that created it (but being a bit more permissive in this code of the capitalization shouldn't be harmful)

Connected to sul-dlss/searchworks_traject_indexer#510 & https://jirasul.stanford.edu/jira/browse/SW-3931