### PR TITLE
Support Rails 7 by requring 'active_support' before any of its components

### DIFF
--- a/lib/stanford-mods.rb
+++ b/lib/stanford-mods.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'mods'
 require 'stanford-mods/date_parsing'
 require 'stanford-mods/coordinate'

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/integer/inflections'
+
 module Stanford
   module Mods
     # Parsing date strings
@@ -228,7 +230,6 @@ module Stanford
 
         century_matches = orig_date_str.match(CENTURY_4CHAR_REGEXP)
         if century_matches
-          require 'active_support/core_ext/integer/inflections'
           return "#{($1.to_i + 1).ordinalize} century"
         end
       end

--- a/lib/stanford-mods/imprint.rb
+++ b/lib/stanford-mods/imprint.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/integer/inflections'
+
 module Stanford
   module Mods
     ##
@@ -400,7 +402,6 @@ module Stanford
           # note:  not calling DateParsing.display_str_for_century directly because non-year text is lost
           century_matches = orig_date_str.match(CENTURY_4CHAR_REGEXP) if orig_date_str
           if century_matches
-            require 'active_support/core_ext/integer/inflections'
             new_century_str = "#{(century_matches[3].to_i + 1).ordinalize} century"
             my_ng_date_element.content = "#{century_matches[1]}#{new_century_str}#{century_matches[4]}"
           else

--- a/spec/date_parsing_spec.rb
+++ b/spec/date_parsing_spec.rb
@@ -272,7 +272,7 @@ describe "date parsing methods" do
     '10/1/90' => '1990',
     '10/21/08' => '2008',
     '5-1-59' => '1959',
-    '5-1-21' => '1921',
+    '5-1-29' => '1929',
     '5-1-14' => '2014'
   }
   # example string as key, expected parsed value as value


### PR DESCRIPTION
See https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support