### PR TITLE
Use BCE and CE dates

### DIFF
--- a/lib/stanford-mods/concerns/origin_info.rb
+++ b/lib/stanford-mods/concerns/origin_info.rb
@@ -15,7 +15,7 @@ module Stanford
       #  look for a keyDate and use it if there is one;  otherwise pick earliest date
       # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute) should be ignored; false if approximate dates should be included
       # @return [Integer] publication year as an Integer
-      # @note for sorting:  5 B.C. => -5;  666 B.C. => -666
+      # @note for sorting:  5 BCE => -5;  666 BCE => -666
       def pub_year_int(fields = [:dateIssued, :dateCreated, :dateCaptured], ignore_approximate: false)
         fields.each do |date_key|
           values = mods_ng_xml.origin_info.send(date_key)
@@ -31,7 +31,7 @@ module Stanford
       #  look for a keyDate and use it if there is one;  otherwise pick earliest date
       # @param [Boolean] ignore_approximate true if approximate dates (per qualifier attribute) should be ignored; false if approximate dates should be included
       # @return [String] single String containing publication year for lexical sorting
-      # @note for string sorting  5 B.C. = -5  => -995;  6 B.C. => -994, so 6 B.C. sorts before 5 B.C.
+      # @note for string sorting  5 BCE = -5  => -995;  6 BCE => -994, so 6 BCE sorts before 5 BCE
       # @deprecated use pub_year_int
       def pub_year_sort_str(fields = [:dateIssued, :dateCreated, :dateCaptured], ignore_approximate: false)
         fields.each do |date_key|
@@ -44,12 +44,12 @@ module Stanford
       end
 
       # return a single string intended for display of pub year
-      # 0 < year < 1000:  add A.D. suffix
-      # year < 0:  add B.C. suffix.  ('-5'  =>  '5 B.C.', '700 B.C.'  => '700 B.C.')
+      # 0 < year < 1000:  add CE suffix
+      # year < 0:  add BCE suffix.  ('-5'  =>  '5 BCE', '700 BCE'  => '700 BCE')
       # 195u =>  195x
       # 19uu => 19xx
-      #   '-5'  =>  '5 B.C.'
-      #   '700 B.C.'  => '700 B.C.'
+      #   '-5'  =>  '5 BCE'
+      #   '700 BCE'  => '700 BCE'
       #   '7th century' => '7th century'
       # date ranges?
       # prefer dateIssued (any) before dateCreated (any) before dateCaptured (any)

--- a/lib/stanford-mods/date_parsing.rb
+++ b/lib/stanford-mods/date_parsing.rb
@@ -15,7 +15,7 @@ module Stanford
         @xml = xml
       end
 
-      # get display value for year, generally an explicit year or "17th century" or "5 B.C." or "1950s" or '845 A.D.'
+      # get display value for year, generally an explicit year or "17th century" or "5 BCE" or "1950s" or '845 CE'
       # @return [String, nil] String value for year if we could parse one, nil otherwise
       def date_str_for_display
         date = xml&.as_object&.date
@@ -32,9 +32,9 @@ module Stanford
           if !self.class.year_int_valid? date.year
             xml.text
           elsif date.year < 1
-            "#{date.year.abs + 1} B.C."
+            "#{date.year.abs + 1} BCE"
           elsif date.year < 1000
-            "#{date.year} A.D."
+            "#{date.year} CE"
           else
             date.year.to_s
           end
@@ -49,7 +49,7 @@ module Stanford
 
       # get String sortable value year if we can parse date_str to get a year.
       #   SearchWorks currently uses a string field for pub date sorting; thus so does Spotlight.
-      #   The values returned must *lexically* sort in chronological order, so the B.C. dates are tricky
+      #   The values returned must *lexically* sort in chronological order, so the BCE dates are tricky
       # @return [String, nil] String sortable year if we could parse one, nil otherwise
       #  note that these values must *lexically* sort to create a chronological sort.
       def sortable_year_string_from_date_str

--- a/lib/stanford-mods/imprint.rb
+++ b/lib/stanford-mods/imprint.rb
@@ -149,7 +149,7 @@ module Stanford
         end
 
         # Element text reduced to digits and hyphen. Captures date ranges and
-        # negative (B.C.) dates. Used for comparison/deduping.
+        # negative (BCE) dates. Used for comparison/deduping.
         def base_value
           if text =~ /^\[?1\d{3}-\d{2}\??\]?$/
             return text.sub(/(\d{2})(\d{2})-(\d{2})/, '\1\2-\1\3')
@@ -193,16 +193,16 @@ module Stanford
           when :year
             year = date.year
             if year < 1
-              "#{year.abs + 1} B.C."
-            # Any dates before the year 1000 are explicitly marked A.D.
+              "#{year.abs + 1} BCE"
+            # Any dates before the year 1000 are explicitly marked CE
             elsif year > 1 && year < 1000
-              "#{year} A.D."
+              "#{year} CE"
             else
               year.to_s
             end
           when :century
             if date.year.negative?
-              "#{((date.year / 100).abs + 1).ordinalize} century B.C."
+              "#{((date.year / 100).abs + 1).ordinalize} century BCE"
             else
               "#{((date.year / 100) + 1).ordinalize} century"
             end
@@ -211,7 +211,7 @@ module Stanford
           end
         end
 
-        # Decoded date with "B.C." or "A.D." and qualifier markers. See (outdated):
+        # Decoded date with "BCE" or "CE" and qualifier markers. See (outdated):
         # https://consul.stanford.edu/display/chimera/MODS+display+rules#MODSdisplayrules-3b.%3CoriginInfo%3E
         def qualified_value
           qualified_format = case qualifier
@@ -250,7 +250,7 @@ module Stanford
           @start&.encoding || @stop&.encoding
         end
 
-        # Decoded dates with "B.C." or "A.D." and qualifier markers applied to
+        # Decoded dates with "BCE" or "CE" and qualifier markers applied to
         # the entire range, or individually if dates differ.
         def qualified_value
           if @start&.qualifier == @stop&.qualifier
@@ -306,7 +306,7 @@ module Stanford
 
         dates = dates - duplicated_ranges
 
-        # output formatted dates with qualifiers, A.D./B.C., etc.
+        # output formatted dates with qualifiers, CE/BCE, etc.
         dates.map(&:qualified_value)
       end
     end

--- a/spec/fixtures/searchworks_imprint_data.rb
+++ b/spec/fixtures/searchworks_imprint_data.rb
@@ -700,7 +700,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <dateIssued encoding="marc" point="start" keyDate="yes">0850</dateIssued>
         <dateIssued encoding="marc" point="end">1499</dateIssued>
         <issuance>monographic</issuance>' +
-        mods_origin_info_end_str => 'California, 850 A.D. - 1499',
+        mods_origin_info_end_str => 'California, 850 CE - 1499',
       # coll rec  bd001pp3337
       # coll rec fn508pj9953
       mods_origin_info_start_str +
@@ -728,7 +728,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <dateCreated point="start" qualifier="approximate" keyDate="yes">850</dateCreated>
         <dateCreated point="end" qualifier="approximate">1499</dateCreated>
         <issuance>monographic</issuance>' +
-        mods_origin_info_end_str => 'England, [ca. 850 A.D. - 1499]',
+        mods_origin_info_end_str => 'England, [ca. 850 CE - 1499]',
       # sc582cv9633
       mods_origin_info_start_str +
         '<dateCreated keydate="yes">1314</dateCreated>
@@ -1055,7 +1055,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <originInfo>
           <dateCreated encoding="edtf" point="start" keyDate="yes">-18</dateCreated>
           <dateCreated encoding="edtf" point="end">-17</dateCreated>' +
-        mods_origin_info_end_str => 'Spain; 19 B.C. - 18 B.C.',
+        mods_origin_info_end_str => 'Spain; 19 BCE - 18 BCE',
       # bb408km1389
       mods_origin_info_start_str +
         ' <place supplied="yes">
@@ -1065,7 +1065,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <originInfo>
           <dateCreated encoding="edtf" point="start" keyDate="yes">-1</dateCreated>
           <dateCreated encoding="edtf" point="end">11</dateCreated>' +
-        mods_origin_info_end_str => 'Lyon (France); 2 B.C. - 11 A.D.',
+        mods_origin_info_end_str => 'Lyon (France); 2 BCE - 11 CE',
       # cs470ng8064
       mods_origin_info_start_str +
         ' <place supplied="yes">
@@ -1075,7 +1075,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <originInfo>
           <dateCreated encoding="edtf" point="start" keyDate="yes">-1</dateCreated>
           <dateCreated encoding="edtf" point="end">0</dateCreated>' +
-        mods_origin_info_end_str => 'Antioch (Turkey) (?); 2 B.C. - 1 B.C.',
+        mods_origin_info_end_str => 'Antioch (Turkey) (?); 2 BCE - 1 BCE',
       # vh834jh5059
       mods_origin_info_start_str +
         ' <place supplied="yes">
@@ -1085,7 +1085,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <originInfo>
           <dateCreated encoding="edtf" point="start" keyDate="yes">13</dateCreated>
           <dateCreated encoding="edtf" point="end">14</dateCreated>' +
-        mods_origin_info_end_str => 'Lyon (France); 13 A.D. - 14 A.D.',
+        mods_origin_info_end_str => 'Lyon (France); 13 CE - 14 CE',
       # sk424bh9379
       mods_origin_info_start_str +
         ' <place supplied="yes">
@@ -1095,7 +1095,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <originInfo>
           <dateCreated encoding="edtf" point="start" keyDate="yes">34</dateCreated>
           <dateCreated encoding="edtf" point="end">35</dateCreated>' +
-        mods_origin_info_end_str => 'Alexandria (Egypt); 34 A.D. - 35 A.D.'
+        mods_origin_info_end_str => 'Alexandria (Egypt); 34 CE - 35 CE'
     },
   # rigler
   'rumsey' =>
@@ -1235,7 +1235,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         '<dateIssued encoding="marc" point="start">800</dateIssued>
         <dateIssued encoding="marc" point="end">1899</dateIssued>
         <issuance>monographic</issuance>' +
-        mods_origin_info_end_str => '800 A.D. - 1899',
+        mods_origin_info_end_str => '800 CE - 1899',
       # dc882bs3541
       mods_origin_info_start_str +
         '<place>
@@ -1245,7 +1245,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <dateCreated encoding="w3cdtf" point="end" qualifier="approximate">0799</dateCreated>
         <dateCreated encoding="w3cdtf" keyDate="yes"/>
         <issuance>monographic</issuance>' +
-        mods_origin_info_end_str => 'Egypt, [ca. 700 A.D. - 799 A.D.]',
+        mods_origin_info_end_str => 'Egypt, [ca. 700 CE - 799 CE]',
       # hg026ds6978
       mods_origin_info_start_str +
         '<place>
@@ -1253,7 +1253,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         </place>
         <dateCreated encoding="w3cdtf" keyDate="yes">0816</dateCreated>
         <issuance>monographic</issuance>' +
-        mods_origin_info_end_str => 'Central Arab lands, 816 A.D.',
+        mods_origin_info_end_str => 'Central Arab lands, 816 CE',
       # ch617yk2621
       mods_origin_info_start_str +
         '<place>
@@ -1273,7 +1273,7 @@ SEARCHWORKS_IMPRINT_DATA = {
         <dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1000</dateCreated>
         <dateCreated encoding="w3cdtf" keyDate="yes"/>
         <issuance>monographic</issuance>' +
-        mods_origin_info_end_str => 'Byzantine Empire, [ca. 950 A.D. - 1000]',
+        mods_origin_info_end_str => 'Byzantine Empire, [ca. 950 CE - 1000]',
       # hj537kj5737
       mods_origin_info_start_str +
         '<dateIssued>15th century CE</dateIssued>

--- a/spec/fixtures/searchworks_pub_date_data.rb
+++ b/spec/fixtures/searchworks_pub_date_data.rb
@@ -607,7 +607,7 @@ SEARCHWORKS_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateIssued encoding="marc" point="start" keyDate="yes">0850</dateIssued>' +
         '<dateIssued encoding="marc" point="end">1499</dateIssued>' +
-        mods_origin_info_end_str => [850, '850 A.D. - 1499'],
+        mods_origin_info_end_str => [850, '850 CE - 1499'],
       # coll rec  bd001pp3337
       mods_origin_info_start_str +
         '<dateIssued encoding="marc" keyDate="yes" point="start">1000</dateIssued>' +
@@ -637,7 +637,7 @@ SEARCHWORKS_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateCreated point="start" qualifier="approximate" keyDate="yes">850</dateCreated>' +
         '<dateCreated point="end" qualifier="approximate">1499</dateCreated>' +
-        mods_origin_info_end_str => [850, '850 A.D. - 1499'],
+        mods_origin_info_end_str => [850, '850 CE - 1499'],
       # sc582cv9633
       mods_origin_info_start_str +
         '<dateCreated keydate="yes">1314</dateCreated>' +
@@ -722,12 +722,12 @@ SEARCHWORKS_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateCreated keyDate="yes" point="start" qualifier="approximate">199 B.C.</dateCreated>' +
         '<dateCreated keyDate="yes" point="end" qualifier="approximate">100 B.C.</dateCreated>' +
-        mods_origin_info_end_str => [-198, '199 B.C. - 100 B.C.'],
+        mods_origin_info_end_str => [-198, '199 BCE - 100 BCE'],
       # ww728rz0477
       mods_origin_info_start_str +
         '<dateCreated keyDate="yes" point="start" qualifier="approximate">211 B.C.</dateCreated>' +
         '<dateCreated keyDate="yes" point="end" qualifier="approximate">150 B.C.</dateCreated>' +
-        mods_origin_info_end_str => [-210, '211 B.C. - 150 B.C.']
+        mods_origin_info_end_str => [-210, '211 BCE - 150 BCE']
     },
   # pcc
   # peace
@@ -796,27 +796,27 @@ SEARCHWORKS_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateCreated encoding="edtf" point="start" keyDate="yes">-18</dateCreated>' +
         '<dateCreated encoding="edtf" point="end">-17</dateCreated>' +
-        mods_origin_info_end_str => [-18, '19 B.C. - 17 B.C.'],
+        mods_origin_info_end_str => [-18, '19 BCE - 17 BCE'],
       # bb408km1389
       mods_origin_info_start_str +
         '<dateCreated encoding="edtf" point="start" keyDate="yes">-1</dateCreated>' +
         '<dateCreated encoding="edtf" point="end">11</dateCreated>' +
-        mods_origin_info_end_str => [-1, '2 B.C. - 11 A.D.'],
+        mods_origin_info_end_str => [-1, '2 BCE - 11 CE'],
       # cs470ng8064
       mods_origin_info_start_str +
         '<dateCreated encoding="edtf" point="start" keyDate="yes">-1</dateCreated>' +
         '<dateCreated encoding="edtf" point="end">0</dateCreated>' +
-        mods_origin_info_end_str => [-1, '2 B.C. - 0 A.D.'],
+        mods_origin_info_end_str => [-1, '2 BCE - 0 CE'],
       # vh834jh5059
       mods_origin_info_start_str +
         '<dateCreated encoding="edtf" point="start" keyDate="yes">13</dateCreated>' +
         '<dateCreated encoding="edtf" point="end">14</dateCreated>' +
-        mods_origin_info_end_str => [13, '13 A.D. - 14 A.D.'],
+        mods_origin_info_end_str => [13, '13 CE - 14 CE'],
       # sk424bh9379
       mods_origin_info_start_str +
         '<dateCreated encoding="edtf" point="start" keyDate="yes">34</dateCreated>' +
         '<dateCreated encoding="edtf" point="end">35</dateCreated>' +
-        mods_origin_info_end_str => [34, '34 A.D. - 35 A.D.']
+        mods_origin_info_end_str => [34, '34 CE - 35 CE']
     },
   # rigler
   # rumsey
@@ -931,23 +931,23 @@ SEARCHWORKS_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateIssued encoding="marc" point="start">800</dateIssued>' +
         '<dateIssued encoding="marc" point="start">1899</dateIssued>' +
-        mods_origin_info_end_str => [800, '800 A.D.'],
+        mods_origin_info_end_str => [800, '800 CE'],
       # dc882bs3541
       mods_origin_info_start_str +
         '<dateCreated encoding="w3cdtf" point="start" qualifier="approximate" keyDate="yes">0700</dateCreated>' +
         '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">0799</dateCreated>' +
         '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
-        mods_origin_info_end_str => [700, '700 A.D. - 799 A.D.'],
+        mods_origin_info_end_str => [700, '700 CE - 799 CE'],
       # hg026ds6978
       mods_origin_info_start_str +
         '<dateCreated encoding="w3cdtf" keyDate="yes">0816</dateCreated>' +
-        mods_origin_info_end_str => [816, '816 A.D.'],
+        mods_origin_info_end_str => [816, '816 CE'],
       # ct437ht0445
       mods_origin_info_start_str +
         '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">0900</dateCreated>' +
         '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">0999</dateCreated>' +
         '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
-        mods_origin_info_end_str => [900, '900 A.D. - 999 A.D.'],
+        mods_origin_info_end_str => [900, '900 CE - 999 CE'],
       # ch617yk2621
       mods_origin_info_start_str +
         '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1000</dateCreated>' +
@@ -959,7 +959,7 @@ SEARCHWORKS_PUB_DATE_DATA = {
         '<dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">0950</dateCreated>' +
         '<dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1000</dateCreated>' +
         '<dateCreated encoding="w3cdtf" keyDate="yes"/>' +
-        mods_origin_info_end_str => [950, '950 A.D. - 1000'],
+        mods_origin_info_end_str => [950, '950 CE - 1000'],
       # hj537kj5737
       mods_origin_info_start_str +
         '<dateIssued>15th century CE</dateIssued>' +

--- a/spec/fixtures/spotlight_pub_date_data.rb
+++ b/spec/fixtures/spotlight_pub_date_data.rb
@@ -156,7 +156,7 @@ SPOTLIGHT_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateIssued encoding="marc" point="start" keyDate="yes">0850</dateIssued>' +
         '<dateIssued encoding="marc" point="end">1499</dateIssued>' +
-        mods_origin_info_end_str => ['0850', '850 A.D.'],
+        mods_origin_info_end_str => ['0850', '850 CE'],
       # nc881qb8504
       mods_origin_info_start_str +
         '<dateCreated point="start" qualifier="approximate" keyDate="yes">1000</dateCreated>' +
@@ -236,12 +236,12 @@ SPOTLIGHT_PUB_DATE_DATA = {
       mods_origin_info_start_str +
         '<dateCreated keyDate="yes" point="start" qualifier="approximate">200 B.C.</dateCreated>' +
         '<dateCreated keyDate="yes" point="end" qualifier="approximate">180 B.C.</dateCreated>' +
-        mods_origin_info_end_str => ['-801', '200 B.C.'],
+        mods_origin_info_end_str => ['-801', '200 BCE'],
       # ww728rz0477
       mods_origin_info_start_str +
         '<dateCreated keyDate="yes" point="start" qualifier="approximate">211 B.C.</dateCreated>' +
         '<dateCreated keyDate="yes" point="end" qualifier="approximate">150 B.C.</dateCreated>' +
-        mods_origin_info_end_str => ['-790', '211 B.C.']
+        mods_origin_info_end_str => ['-790', '211 BCE']
     },
   'renaissance' =>
     { # key is mods_xml;  values = [pub date sortable facet value, pub date single string facet value]

--- a/spec/imprint_spec.rb
+++ b/spec/imprint_spec.rb
@@ -129,7 +129,7 @@ describe Stanford::Mods::Imprint do
       expect(updated_element).to eq '1470s'
     end
 
-    it 'adds A.D. to early years' do
+    it 'adds CE to early years' do
       smods_rec.from_str <<-XML
         #{mods_origin_info_start_str}
           <dateIssued encoding="edtf">988</dateIssued>
@@ -138,10 +138,10 @@ describe Stanford::Mods::Imprint do
 
       imp = stanford_mods_imprint(smods_rec)
       updated_element = imp.send(:date_str)
-      expect(updated_element).to eq '988 A.D.'
+      expect(updated_element).to eq '988 CE'
     end
 
-    it 'adds B.C. to B.C. years' do
+    it 'adds BCE to BCE years' do
       smods_rec.from_str <<-XML
         #{mods_origin_info_start_str}
           <dateIssued encoding="edtf">-5</dateIssued>
@@ -150,10 +150,10 @@ describe Stanford::Mods::Imprint do
 
       imp = stanford_mods_imprint(smods_rec)
       updated_element = imp.send(:date_str)
-      expect(updated_element).to eq '6 B.C.'
+      expect(updated_element).to eq '6 BCE'
     end
 
-    it 'has special handling for the year 0 (1 B.C.)' do
+    it 'has special handling for the year 0 (1 BCE)' do
       smods_rec.from_str <<-XML
         #{mods_origin_info_start_str}
           <dateIssued>0</dateIssued>
@@ -162,7 +162,7 @@ describe Stanford::Mods::Imprint do
 
       imp = stanford_mods_imprint(smods_rec)
       updated_element = imp.send(:date_str)
-      expect(updated_element).to eq '1 B.C.'
+      expect(updated_element).to eq '1 BCE'
     end
 
     it 'presents years + months' do
@@ -211,7 +211,7 @@ describe Stanford::Mods::Imprint do
 
       imp = stanford_mods_imprint(smods_rec)
       updated_element = imp.send(:date_str)
-      expect(updated_element).to eq '10th century B.C.'
+      expect(updated_element).to eq '10th century BCE'
     end
 
     it 'handles the approximate qualifier' do
@@ -235,7 +235,7 @@ describe Stanford::Mods::Imprint do
 
       imp = stanford_mods_imprint(smods_rec)
       updated_element = imp.send(:date_str)
-      expect(updated_element).to eq '[322 A.D.?]'
+      expect(updated_element).to eq '[322 CE?]'
     end
 
     it 'handles the inferred qualifier' do

--- a/spec/origin_info_spec.rb
+++ b/spec/origin_info_spec.rb
@@ -89,7 +89,7 @@ describe "computations from /originInfo field" do
   context '#pub_year_int' do
     it_behaves_like "single pub date value", :pub_year_int, 0
     # papyri - the only Spotlight data with BC dates
-    it '-200 for 200 B.C.' do
+    it '-199 for 200 B.C.' do
       # hd778hw9236
       mods_str = mods_origin_info_start_str +
         '<dateCreated keyDate="yes" point="start" qualifier="approximate">200 B.C.</dateCreated>' +
@@ -98,7 +98,7 @@ describe "computations from /originInfo field" do
       smods_rec.from_str(mods_str)
       expect(smods_rec.pub_year_int).to eq(-199)
     end
-    it '-211 for 211 B.C.' do
+    it '-210 for 211 B.C.' do
       # ww728rz0477
       mods_str = mods_origin_info_start_str +
         '<dateCreated keyDate="yes" point="start" qualifier="approximate">211 B.C.</dateCreated>' +


### PR DESCRIPTION
- Correct off-by-one error in test descriptions
- Replace BC and AD dates with BCE and CE
