### PR TITLE
Ignore 1uuu year.

### DIFF
--- a/lib/stanford-mods/imprint.rb
+++ b/lib/stanford-mods/imprint.rb
@@ -144,7 +144,7 @@ module Stanford
 
         # True if the element text isn't blank or the placeholder "9999".
         def valid?
-          text.present? && !['9999', '0000-00-00', 'uuuu'].include?(text.strip)
+          text.present? && !['9999', '0000-00-00', 'uuuu', '1uuu'].include?(text.strip)
         end
 
         def key_date?

--- a/spec/imprint_spec.rb
+++ b/spec/imprint_spec.rb
@@ -21,6 +21,9 @@ describe Stanford::Mods::Imprint do
             uuuu
           </dateIssued>
           <dateIssued>
+            1uuu
+          </dateIssued>          
+          <dateIssued>
             0000-00-00
           </dateIssued>' +
         mods_origin_info_end_str)


### PR DESCRIPTION
See https://app.honeybadger.io/projects/49898/faults/100703773

EDTF doesn't allow `1uuu`:
```
irb(main):011:0> d = Date.edtf('1uuu')
=> nil
```