### PR TITLE
Treat [uuuu] as an invalid date.

### DIFF
--- a/lib/stanford-mods.rb
+++ b/lib/stanford-mods.rb
@@ -1,5 +1,6 @@
 require 'active_support'
 require 'active_support/core_ext/integer/inflections'
+require 'active_support/core_ext/object/blank'
 require 'mods'
 require 'stanford-mods/coordinate'
 require 'stanford-mods/imprint'

--- a/lib/stanford-mods/imprint.rb
+++ b/lib/stanford-mods/imprint.rb
@@ -144,7 +144,7 @@ module Stanford
 
         # True if the element text isn't blank or the placeholder "9999".
         def valid?
-          text.present? && !['9999', '0000-00-00', 'uuuu'].include?(text.strip)
+          text.present? && !['9999', '0000-00-00', 'uuuu', '[uuuu]'].include?(text.strip)
         end
 
         def key_date?
@@ -161,7 +161,7 @@ module Stanford
 
         def sort_key
           return unless date
-          
+
           year = if date.is_a?(EDTF::Interval)
             date.from.year
           else

--- a/spec/imprint_spec.rb
+++ b/spec/imprint_spec.rb
@@ -21,6 +21,9 @@ describe Stanford::Mods::Imprint do
             uuuu
           </dateIssued>
           <dateIssued>
+            [uuuu]
+          </dateIssued>
+          <dateIssued>
             0000-00-00
           </dateIssued>' +
         mods_origin_info_end_str)


### PR DESCRIPTION
See https://app.honeybadger.io/projects/49898/faults/101052861 which is caused by https://folio.stanford.edu/inventory/view/31809beb-f7f0-505b-bcaf-c054a1899c42?query=a12321438&sort=title