### PR TITLE
pin mods gem to 3.0.4 for name/nameIdentifier (orcids)

### DIFF
--- a/stanford-mods.gemspec
+++ b/stanford-mods.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'mods', '~> 3.0', '>= 3.0.3'
+  gem.add_dependency 'mods', '~> 3.0', '>= 3.0.4'
   # active_support for .ordinalize, eg. 1 -> 1st, 2 -> 2nd for centuries
   gem.add_dependency 'activesupport'
 


### PR DESCRIPTION
part of sul-dlss/purl/issues/717 

The mods gem was written for MODS 3.4; MODS is now at 3.8 and SDR puts contributor ORCID into the sub-element name/nameIdentifier ... which is why mods 3.0.4 was released.  

This sets us up to work with nameIdentifier in stanford-mods in the future, if we so choose.