### PR TITLE
Handle BCE dates, up to Y-999999999 

### DIFF
--- a/spec/origin_info_spec.rb
+++ b/spec/origin_info_spec.rb
@@ -383,7 +383,7 @@ describe "computations from /originInfo field" do
       end
 
       it 'returns the earliest date with the funky lexical sort encoding' do
-        expect(record.pub_year_sort_str).to eq '-751'
+        expect(record.pub_year_sort_str).to eq '-6750'
       end
     end
 
@@ -400,7 +400,23 @@ describe "computations from /originInfo field" do
       end
 
       it 'returns the earliest date of the range with the funky lexical sort encoding' do
-        expect(record.pub_year_sort_str).to eq '-751'
+        expect(record.pub_year_sort_str).to eq '-6750'
+      end
+    end
+
+    context 'with a really old BCE date (e.g. ky899rv1161)' do
+      let(:modsxml) do
+        <<-EOF
+          <mods xmlns="http://www.loc.gov/mods/v3">
+            <originInfo>
+              <dateIssued encoding="edtf">Y-12345</dateIssued>
+            </originInfo>
+          </mods>
+        EOF
+      end
+
+      it 'returns the earliest date of the range with the funky lexical sort encoding' do
+        expect(record.pub_year_sort_str).to eq '-487654'
       end
     end
 


### PR DESCRIPTION
(that ought to be enough for anyone, right?)

Fixes https://github.com/sul-dlss/searchworks_traject_indexer/issues/1319

Our current algorithm doesn't work for BCE dates earlier than 1000 BCE (all 17 records..). 

This replaces https://github.com/sul-dlss/stanford-mods/pull/148, which works for dates until 10000 BCE (and we now have 2 from even earlier).

This PR prefixes the BCE values with the number of characters and inverts all the digits so the value sorts as expected, with the longest years sorting lexically earlier and e.g. 9 BCE sorts before 1 BCE:

```
-12345 (12346 BCE) => '-487654' (was 11345.. oops)
-250 (251 BCE) => '-6749' (was -749)
-249 (250 BCE) => '-6750' (was -750)
```

Searchworks may be the only consumer of this method, and this will require reindexing the ~400 BCE objects to get them to sort correctly.